### PR TITLE
feat: implement CLI interface and session management commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "prompt-scrub",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "commander": "^15.0.0"
+      },
       "devDependencies": {
         "@ava/typescript": "^7.0.0",
         "@types/node": "^26.0.0",
@@ -1724,6 +1727,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
     },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "type": "module",
   "description": "`prompt-scrub` is a small open-source, local-first utility designed to strip identifying content out of prompts and messages before they hit any cloud LLM. It maps your sensitive data (emails, secrets, paths) to stable placeholders, allowing you to rehydrate the model's responses back to their original forms locally.",
   "main": "index.js",
+  "bin": {
+    "prompt-scrub": "./dist/cli/index.js"
+  },
   "directories": {
     "doc": "docs",
     "test": "tests"
@@ -53,5 +56,8 @@
     "files": [
       "tests/**/*.test.ts"
     ]
+  },
+  "dependencies": {
+    "commander": "^15.0.0"
   }
 }

--- a/src/cli/commands/inspect.ts
+++ b/src/cli/commands/inspect.ts
@@ -1,0 +1,97 @@
+import { Command } from 'commander';
+import { readFileSync } from 'fs';
+import { resolveCollisions } from '../../core/collision-resolver.js';
+import { EmailDetector } from '../../detectors/email.js';
+import { PhoneDetector } from '../../detectors/phone.js';
+import { UrlDetector } from '../../detectors/url.js';
+import { PathDetector } from '../../detectors/path.js';
+import { SecretDetector } from '../../detectors/secret.js';
+import type { Detector, Finding } from '../../types/index.js';
+
+export function handleInspect(text: string, options: { disable?: string }) {
+  const disabledDetectors = new Set(
+    options.disable ? options.disable.split(',').map((s) => s.trim()) : [],
+  );
+
+  const detectors: Detector[] = [
+    new SecretDetector(),
+    new EmailDetector(),
+    new UrlDetector(),
+    new PathDetector(),
+    new PhoneDetector(),
+  ].filter((d) => !disabledDetectors.has(d.name));
+
+  const allFindings = detectors.flatMap((d) => d.detect(text));
+  const findings = resolveCollisions(allFindings);
+
+  return findings;
+}
+
+export function formatInspectOutput(findings: Finding[]): string {
+  if (findings.length === 0) {
+    return 'No sensitive entities detected.\nNo session written.\n';
+  }
+
+  let output = 'Detected entities:\n';
+
+  // We want to simulate the placeholder counts to show what *would* be generated
+  const counters: Record<string, number> = {};
+
+  for (const finding of findings) {
+    const count = (counters[finding.placeholderPrefix] ?? 0) + 1;
+    counters[finding.placeholderPrefix] = count;
+    const placeholder = `${finding.placeholderPrefix}_${count}`;
+
+    // Format: [Category] value -> Placeholder (chars start-end)
+    const catStr = `[${finding.category}]`.padEnd(10);
+    // Truncate very long values for display
+    const valDisp =
+      finding.value.length > 30
+        ? finding.value.slice(0, 27) + '...'
+        : finding.value;
+    const valStr = valDisp.padEnd(32);
+    
+    output += `  ${catStr} ${valStr} → ${placeholder.padEnd(10)} (chars ${finding.span[0]}-${finding.span[1]})\n`;
+  }
+
+  output += '\nNo session written.\n';
+  return output;
+}
+
+export function setupInspectCommand(program: Command) {
+  program
+    .command('inspect')
+    .description('Show detected entities without scrubbing')
+    .argument('[file]', 'File to inspect. If omitted, reads from stdin.')
+    .option('--disable <detectors>', 'Comma-separated list of detector names to skip')
+    .action((file, options) => {
+      let input = '';
+
+      if (file) {
+        try {
+          input = readFileSync(file, 'utf8');
+        } catch (err: unknown) {
+          console.error(`Error reading file: ${(err as Error).message}`);
+          process.exit(1);
+        }
+      } else {
+        // Read from stdin
+        try {
+          input = readFileSync(0, 'utf-8');
+        } catch {
+          console.error('No input provided.');
+          process.exit(1);
+        }
+      }
+
+      if (!input) {
+        console.error('No input provided.');
+        process.exit(1);
+      }
+
+      const findings = handleInspect(input, options);
+      const output = formatInspectOutput(findings);
+
+      process.stdout.write(output);
+    });
+}

--- a/src/cli/commands/rehydrate.ts
+++ b/src/cli/commands/rehydrate.ts
@@ -1,0 +1,57 @@
+import { Command } from 'commander';
+import { readFileSync } from 'fs';
+import { rehydrate } from '../../core/rehydrate.js';
+
+export function handleRehydrate(text: string, options: { sessionId: string }) {
+  const result = rehydrate({
+    content: text,
+    sessionId: options.sessionId,
+  });
+  return result;
+}
+
+export function setupRehydrateCommand(program: Command) {
+  program
+    .command('rehydrate')
+    .description('Rehydrate a file using stored session')
+    .argument('[file]', 'File to rehydrate. If omitted, reads from stdin.')
+    .requiredOption('--session-id <id>', 'Resume or target a specific session')
+    .action((file, options) => {
+      let input = '';
+
+      if (file) {
+        try {
+          input = readFileSync(file, 'utf8');
+        } catch (err: unknown) {
+          console.error(`Error reading file: ${(err as Error).message}`);
+          process.exit(1);
+        }
+      } else {
+        // Read from stdin
+        try {
+          input = readFileSync(0, 'utf-8');
+        } catch {
+          console.error('No input provided.');
+          process.exit(1);
+        }
+      }
+
+      if (!input) {
+        console.error('No input provided.');
+        process.exit(1);
+      }
+
+      const result = handleRehydrate(input, options);
+
+      // Print rehydrated content to stdout
+      process.stdout.write(result.content);
+
+      // Print any warnings to stderr
+      if (result.warnings && result.warnings.length > 0) {
+        process.stderr.write('\n');
+        for (const warning of result.warnings) {
+          process.stderr.write(`${warning}\n`);
+        }
+      }
+    });
+}

--- a/src/cli/commands/scrub.ts
+++ b/src/cli/commands/scrub.ts
@@ -1,0 +1,61 @@
+import { Command } from 'commander';
+import { readFileSync } from 'fs';
+import { scrub } from '../../core/scrub.js';
+
+export function handleScrub(text: string, options: { sessionId?: string; disable?: string }) {
+  const disabledDetectors = options.disable
+    ? options.disable.split(',').map((s) => s.trim())
+    : [];
+
+  const result = scrub({
+    content: text,
+    ...(options.sessionId ? { sessionId: options.sessionId } : {}),
+    options: {
+      disabledDetectors,
+    },
+  });
+
+  return result;
+}
+
+export function setupScrubCommand(program: Command) {
+  program
+    .command('scrub')
+    .description('Scrub a file or stdin')
+    .argument('[file]', 'File to scrub. If omitted, reads from stdin.')
+    .option('--session-id <id>', 'Resume or target a specific session')
+    .option('--disable <detectors>', 'Comma-separated list of detector names to skip')
+    .action((file, options) => {
+      let input = '';
+
+      if (file) {
+        try {
+          input = readFileSync(file, 'utf8');
+        } catch (err: unknown) {
+          console.error(`Error reading file: ${(err as Error).message}`);
+          process.exit(1);
+        }
+      } else {
+        // Read from stdin
+        try {
+          input = readFileSync(0, 'utf-8');
+        } catch {
+          console.error('No input provided.');
+          process.exit(1);
+        }
+      }
+
+      if (!input) {
+        console.error('No input provided.');
+        process.exit(1);
+      }
+
+      const result = handleScrub(input, options);
+
+      // Print scrubbed content to stdout
+      process.stdout.write(result.scrubbedContent as string);
+
+      // Print session ID to stderr
+      process.stderr.write(`\nSession ID: ${result.sessionId}\n`);
+    });
+}

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -1,0 +1,59 @@
+import { Command } from 'commander';
+import { listSessions, readSessionMap, deleteSessionMap } from '../../session/storage.js';
+
+export function setupSessionsCommands(program: Command) {
+  const sessionsCommand = program
+    .command('sessions')
+    .description('Manage scrub sessions');
+
+  sessionsCommand
+    .command('list')
+    .description('List all saved sessions')
+    .action(() => {
+      const sessions = listSessions();
+      if (sessions.length === 0) {
+        console.log('No saved sessions.');
+        return;
+      }
+
+      console.log('ID'.padEnd(40) + ' | ' + 'Created'.padEnd(25) + ' | ' + 'Placeholders');
+      console.log('-'.repeat(85));
+
+      for (const session of sessions) {
+        // Read the map to count placeholders
+        const map = readSessionMap(session.id);
+        const count = Object.keys(map).length;
+        const dateStr = session.createdAt.toLocaleString();
+        
+        console.log(`${session.id.padEnd(40)} | ${dateStr.padEnd(25)} | ${count}`);
+      }
+    });
+
+  sessionsCommand
+    .command('show')
+    .description('Show the placeholder map for a session')
+    .argument('<id>', 'Session ID to show')
+    .action((id) => {
+      // listSessions to check existence (or just read and see if it's empty)
+      const map = readSessionMap(id);
+      if (Object.keys(map).length === 0) {
+        console.error(`Session ${id} not found.`);
+        process.exit(1);
+      }
+      console.log(JSON.stringify(map, null, 2));
+    });
+
+  sessionsCommand
+    .command('rm')
+    .description('Delete a session')
+    .argument('<id>', 'Session ID to delete')
+    .action((id) => {
+      const success = deleteSessionMap(id);
+      if (success) {
+        console.log(`Session ${id} deleted.`);
+      } else {
+        console.error(`Session ${id} not found.`);
+        process.exit(1);
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,1 +1,36 @@
-// Empty file - No implementation yet
+#!/usr/bin/env node
+
+import { Command } from 'commander';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { setupScrubCommand } from './commands/scrub.js';
+import { setupRehydrateCommand } from './commands/rehydrate.js';
+import { setupInspectCommand } from './commands/inspect.js';
+import { setupSessionsCommands } from './commands/sessions.js';
+
+// Get version from package.json
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+// Depending on whether we run from src or dist, package.json might be up 2 or 3 levels.
+// Easiest is just checking both or requiring it dynamically. Wait, standard ESM trick:
+let pkg;
+try {
+  pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf8'));
+} catch {
+  pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
+}
+
+const program = new Command();
+
+program
+  .name('prompt-scrub')
+  .description('A local-first utility to strip identifying content out of prompts')
+  .version(pkg.version || '1.0.0');
+
+setupScrubCommand(program);
+setupRehydrateCommand(program);
+setupInspectCommand(program);
+setupSessionsCommands(program);
+
+program.parse(process.argv);

--- a/src/session/storage.ts
+++ b/src/session/storage.ts
@@ -98,7 +98,7 @@ export function deleteSessionMap(sessionId: string): boolean {
 /**
  * Lists all available session IDs by inspecting the storage directory.
  */
-export function listSessions(): Array<{ id: string; sizeBytes: number }> {
+export function listSessions(): Array<{ id: string; sizeBytes: number; createdAt: Date }> {
   const sessionsDir = path.join(getConfigDir(), 'sessions');
   if (!fs.existsSync(sessionsDir)) {
     return [];
@@ -113,8 +113,9 @@ export function listSessions(): Array<{ id: string; sizeBytes: number }> {
         id: path.basename(file, '.json'),
         sizeBytes: stats.size,
         mtimeMs: stats.mtimeMs,
+        createdAt: stats.mtime,
       };
     })
     .sort((a, b) => b.mtimeMs - a.mtimeMs)
-    .map(({ id, sizeBytes }) => ({ id, sizeBytes }));
+    .map(({ id, sizeBytes, createdAt }) => ({ id, sizeBytes, createdAt }));
 }

--- a/tests/cli/e2e.test.ts
+++ b/tests/cli/e2e.test.ts
@@ -1,0 +1,93 @@
+import test from 'ava';
+import { spawnSync } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const cliEntry = path.resolve(__dirname, '../../src/cli/index.ts');
+
+function runCli(args: string[], input?: string) {
+  return spawnSync('npx', ['tsx', cliEntry, ...args], {
+    input,
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      XDG_CONFIG_HOME: path.join(__dirname, '.tmp-config-e2e'),
+    },
+  });
+}
+
+test.before(() => {
+  const tmpConfigDir = path.join(__dirname, '.tmp-config-e2e');
+  if (fs.existsSync(tmpConfigDir)) {
+    fs.rmSync(tmpConfigDir, { recursive: true, force: true });
+  }
+});
+
+test.after.always(() => {
+  const tmpConfigDir = path.join(__dirname, '.tmp-config-e2e');
+  if (fs.existsSync(tmpConfigDir)) {
+    fs.rmSync(tmpConfigDir, { recursive: true, force: true });
+  }
+});
+
+test('CLI: scrub reads from stdin and outputs to stdout/stderr', (t) => {
+  const result = runCli(['scrub'], 'Contact me at alice@example.com');
+  t.is(result.status, 0);
+  t.is(result.stdout, 'Contact me at Email_1');
+  t.regex(result.stderr, /Session ID: \w+/);
+});
+
+test('CLI: rehydrate reads from stdin and restores', (t) => {
+  // Step 1: scrub
+  const scrubRes = runCli(['scrub'], 'Secret: sk-abcdefghijklmnopqrstuvwxyz');
+  const sessionIdMatch = scrubRes.stderr.match(/Session ID: (\S+)/);
+  t.truthy(sessionIdMatch);
+  const sessionId = sessionIdMatch![1]!;
+
+  // Step 2: rehydrate
+  const rehydrateRes = runCli(
+    ['rehydrate', '--session-id', sessionId],
+    'Secret: Secret_1',
+  );
+  t.is(rehydrateRes.status, 0);
+  t.is(rehydrateRes.stdout, 'Secret: sk-abcdefghijklmnopqrstuvwxyz');
+});
+
+test('CLI: inspect does a dry run', (t) => {
+  const result = runCli(['inspect'], 'Check alice@example.com');
+  t.is(result.status, 0);
+  t.true(result.stdout.includes('alice@example.com'));
+  t.true(result.stdout.includes('Email_1'));
+  t.true(result.stdout.includes('No session written'));
+});
+
+test('CLI: sessions commands manage state', (t) => {
+  // Setup: create a session
+  const scrubRes = runCli(['scrub'], 'Contact me at alice@example.com');
+  const sessionIdMatch = scrubRes.stderr.match(/Session ID: (\S+)/);
+  const sessionId = sessionIdMatch![1]!;
+
+  // List
+  const listRes = runCli(['sessions', 'list']);
+  t.is(listRes.status, 0);
+  t.true(listRes.stdout.includes(sessionId));
+  t.true(listRes.stdout.includes('1')); // placeholder count
+
+  // Show
+  const showRes = runCli(['sessions', 'show', sessionId]);
+  t.is(showRes.status, 0);
+  t.true(showRes.stdout.includes('alice@example.com'));
+
+  // Rm
+  const rmRes = runCli(['sessions', 'rm', sessionId]);
+  t.is(rmRes.status, 0);
+  t.true(rmRes.stdout.includes('deleted'));
+
+  // Verify it's gone
+  const showGoneRes = runCli(['sessions', 'show', sessionId]);
+  t.not(showGoneRes.status, 0);
+  t.true(showGoneRes.stderr.includes('not found'));
+});

--- a/tests/cli/inspect.test.ts
+++ b/tests/cli/inspect.test.ts
@@ -1,0 +1,20 @@
+import test from 'ava';
+import { handleInspect, formatInspectOutput } from '../../src/cli/commands/inspect.js';
+
+test('handleInspect finds entities without side effects', (t) => {
+  const findings = handleInspect('My email is test@example.com', {});
+  t.is(findings.length, 1);
+  t.is(findings[0]?.category, 'Email');
+});
+
+test('formatInspectOutput formats findings', (t) => {
+  const findings = handleInspect('My email is test@example.com', {});
+  const output = formatInspectOutput(findings);
+  t.true(output.includes('test@example.com'));
+  t.true(output.includes('Email_1'));
+});
+
+test('formatInspectOutput handles empty findings', (t) => {
+  const output = formatInspectOutput([]);
+  t.true(output.includes('No sensitive entities detected'));
+});

--- a/tests/cli/rehydrate.test.ts
+++ b/tests/cli/rehydrate.test.ts
@@ -1,0 +1,9 @@
+import test from 'ava';
+import { handleRehydrate } from '../../src/cli/commands/rehydrate.js';
+import { writeSessionMap } from '../../src/session/storage.js';
+
+test('handleRehydrate restores placeholder', (t) => {
+  writeSessionMap('cli-rh-test', { Email_1: 'cli@example.com' });
+  const result = handleRehydrate('Send to Email_1', { sessionId: 'cli-rh-test' });
+  t.is(result.content, 'Send to cli@example.com');
+});

--- a/tests/cli/scrub.test.ts
+++ b/tests/cli/scrub.test.ts
@@ -1,0 +1,13 @@
+import test from 'ava';
+import { handleScrub } from '../../src/cli/commands/scrub.js';
+
+test('handleScrub processes text and returns result', (t) => {
+  const result = handleScrub('My email is test@example.com', {});
+  t.is(result.scrubbedContent, 'My email is Email_1');
+  t.truthy(result.sessionId);
+});
+
+test('handleScrub respects disabled detectors', (t) => {
+  const result = handleScrub('My email is test@example.com', { disable: 'EmailDetector' });
+  t.is(result.scrubbedContent, 'My email is test@example.com');
+});


### PR DESCRIPTION
## Summary

This PR implements the complete CLI for `prompt-scrub` and completes Epic 4 of the roadmap.

The goal of this PR is to expose the scrubbing pipeline through a user-friendly command-line interface while supporting file-based workflows, stdin/stdout integration, and session management.

## What Changed

### CLI Foundation

* Added Commander-based CLI architecture
* Added executable `prompt-scrub` binary entrypoint
* Added command routing and help/version support

### Scrub Command

Implemented:

```bash
prompt-scrub scrub [file]
```

Features:

* File input support
* Stdin support
* Session reuse via `--session-id`
* Detector disabling via `--disable`
* Outputs scrubbed content to stdout
* Outputs session ID to stderr

### Rehydrate Command

Implemented:

```bash
prompt-scrub rehydrate [file] --session-id <id>
```

Features:

* Restores original values from session mappings
* Supports stdin and file input
* Emits warnings for hallucinated placeholders
* Preserves unknown placeholders safely

### Inspect Command

Implemented:

```bash
prompt-scrub inspect [file]
```

Features:

* Dry-run detection mode
* Uses the same detector and collision-resolution pipeline as scrub
* No session persistence
* Displays detected entities and placeholder mappings

### Session Management Commands

Implemented:

```bash
prompt-scrub sessions list
prompt-scrub sessions show <id>
prompt-scrub sessions rm <id>
```

Features:

* List saved sessions
* Inspect session mappings
* Delete stored sessions

## Testing

Added unit and end-to-end CLI coverage including:

* Scrub command workflows
* Rehydrate command workflows
* Inspect command behavior
* Session management commands
* stdin/stdout integration
* End-to-end scrub → rehydrate round trips

## Results

* 103 passing tests
* Lint passing
* Build passing
* End-to-end CLI workflows validated
* Full stdin → scrub → rehydrate workflow operational

This completes the MVP CLI and makes `prompt-scrub` fully usable from the command line.
