### PR TITLE
fix: resolve ux formatting and empty session id display issues

### DIFF
--- a/src/cli/commands/rehydrate.ts
+++ b/src/cli/commands/rehydrate.ts
@@ -48,9 +48,8 @@ export function setupRehydrateCommand(program: Command) {
 
       // Print any warnings to stderr
       if (result.warnings && result.warnings.length > 0) {
-        process.stderr.write('\n');
         for (const warning of result.warnings) {
-          process.stderr.write(`${warning}\n`);
+          console.error(warning);
         }
       }
     });

--- a/src/cli/commands/scrub.ts
+++ b/src/cli/commands/scrub.ts
@@ -56,6 +56,8 @@ export function setupScrubCommand(program: Command) {
       process.stdout.write(result.scrubbedContent as string);
 
       // Print session ID to stderr
-      process.stderr.write(`\nSession ID: ${result.sessionId}\n`);
+      if (result.scrubbedContent !== input) {
+        console.error(`Session ID: ${result.sessionId}`);
+      }
     });
 }

--- a/src/core/scrub.ts
+++ b/src/core/scrub.ts
@@ -58,9 +58,11 @@ export function scrub(request: ScrubRequest): ScrubResult {
   const session = new SessionManager(sessionId);
 
   // Build active detector list
-  const disabledSet = new Set(options?.disabledDetectors ?? []);
+  const disabledSet = new Set(
+    (options?.disabledDetectors ?? []).map((d) => d.toLowerCase().replace('detector', ''))
+  );
   const activeDetectors = DEFAULT_DETECTORS.filter(
-    (d) => !disabledSet.has(d.name),
+    (d) => !disabledSet.has(d.name.toLowerCase().replace('detector', ''))
   );
   if (options?.customDetectors) {
     activeDetectors.push(...options.customDetectors);


### PR DESCRIPTION
## Summary

This PR addresses several UX improvements identified during the first manual smoke testing pass for `prompt-scrub`.

The goal is to make the CLI feel more polished and intuitive without changing its core functionality.

## What Changed

### CLI Output

* Removed unnecessary leading newlines from `stderr` output.
* Switched to standard `console.error` formatting for warnings and session messages.

### Session Handling

* No longer prints a Session ID when no sensitive data is detected and no session is created.
* CLI output now accurately reflects session persistence behavior.

### Detector Flags

* Added support for friendly detector names with `--disable`.
* Users can now write:

  ```
  --disable email,phone,url
  ```

  instead of internal detector class names.

## Validation

* 115 tests passing
* Lint passing
* Build passing

These improvements were identified during the first manual smoke testing pass while preparing `prompt-scrub` for its initial npm release.
