### PR TITLE
feat: add Postal Address detector

### DIFF
--- a/docs/features/detectors.md
+++ b/docs/features/detectors.md
@@ -33,6 +33,7 @@ export interface Detector {
 - `UrlDetector`: Detects full URLs (with allowlist support).
 - `PathDetector`: Detects absolute paths and home directories.
 - `SecretDetector`: Detects high-entropy strings, API keys, and tokens.
+- `AddressDetector`: Detects unambiguous postal addresses (e.g., street shapes).
 
 ## Priority & Collision System
 
@@ -44,6 +45,7 @@ Priority is implicitly handled by a defined order of precedence:
 3. `UrlDetector`
 4. `PathDetector`
 5. `PhoneDetector`
+6. `AddressDetector`
 
 If `SecretDetector` and `UrlDetector` match the same string (e.g., a URL with a token), `SecretDetector` wins.
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
       "--no-warnings",
       "--import=tsx"
     ],
+    "workerThreads": false,
     "files": [
       "tests/**/*.test.ts"
     ]

--- a/src/core/collision-resolver.ts
+++ b/src/core/collision-resolver.ts
@@ -7,6 +7,7 @@ const DETECTOR_PRIORITY: Record<string, number> = {
   UrlDetector: 3,
   PathDetector: 4,
   PhoneDetector: 5,
+  AddressDetector: 6,
 };
 
 function priorityOf(finding: Finding): number {

--- a/src/core/scrub.ts
+++ b/src/core/scrub.ts
@@ -6,6 +6,7 @@ import { PhoneDetector } from '../detectors/phone.js';
 import { UrlDetector } from '../detectors/url.js';
 import { PathDetector } from '../detectors/path.js';
 import { SecretDetector } from '../detectors/secret.js';
+import { PostalAddressDetector } from '../detectors/postal-address.js';
 
 const DEFAULT_DETECTORS: Detector[] = [
   new SecretDetector(),
@@ -13,6 +14,7 @@ const DEFAULT_DETECTORS: Detector[] = [
   new UrlDetector(),
   new PathDetector(),
   new PhoneDetector(),
+  new PostalAddressDetector(),
 ];
 
 /**

--- a/src/detectors/postal-address.ts
+++ b/src/detectors/postal-address.ts
@@ -1,0 +1,30 @@
+import type { Detector, Finding } from '../types/index.js';
+
+// Conservative matching only: number + word(s) + street suffix.
+// Examples: 123 Main Street, 45 Oak Road, 1600 Pennsylvania Ave., 10 Downing St, 221B Baker St.
+const ADDRESS_REGEX =
+  /\b\d{1,6}[A-Za-z]?\s+[A-Za-z0-9\s.,'-]+?\b(?:street|st|road|rd|avenue|ave|boulevard|blvd|lane|ln|drive|dr|court|ct|place|pl|square|sq|terrace|ter)\b\.?/gi;
+
+export class PostalAddressDetector implements Detector {
+  readonly name = 'AddressDetector';
+
+  detect(text: string): Finding[] {
+    const findings: Finding[] = [];
+    let match: RegExpExecArray | null;
+
+    ADDRESS_REGEX.lastIndex = 0;
+
+    while ((match = ADDRESS_REGEX.exec(text)) !== null) {
+      const value = match[0];
+
+      findings.push({
+        category: 'Address',
+        span: [match.index, match.index + value.length],
+        value,
+        placeholderPrefix: 'Address',
+      });
+    }
+
+    return findings;
+  }
+}

--- a/tests/core/scrub.test.ts
+++ b/tests/core/scrub.test.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { scrub } from '../../src/core/scrub.js';
+import { rehydrate } from '../../src/core/rehydrate.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -138,4 +139,18 @@ test('Message[] input: each message gets its own scrubbing within shared session
   // Same email in both messages should map to same placeholder
   t.is(messages[0]?.content, 'From Email_1');
   t.is(messages[1]?.content, 'Also from Email_1');
+});
+
+test('postal address round-tripping works correctly', (t) => {
+  const text = 'Send it to 123 Main Street or 1600 Pennsylvania Ave.';
+  const scrubbed = scrub({ content: text });
+
+  t.is(scrubbed.scrubbedContent, 'Send it to Address_2 or Address_1');
+
+  const restored = rehydrate({
+    content: scrubbed.scrubbedContent as string,
+    sessionId: scrubbed.sessionId,
+  });
+
+  t.is(restored.content, text);
 });

--- a/tests/detectors/postal-address.test.ts
+++ b/tests/detectors/postal-address.test.ts
@@ -1,0 +1,60 @@
+import test from 'ava';
+import { PostalAddressDetector } from '../../src/detectors/postal-address.js';
+
+const detector = new PostalAddressDetector();
+
+// --- Positive Cases ---
+
+test('detects basic street address', (t) => {
+  const findings = detector.detect('Meet me at 123 Main Street tomorrow.');
+  t.is(findings.length, 1);
+  t.is(findings[0]?.value, '123 Main Street');
+  t.is(findings[0]?.placeholderPrefix, 'Address');
+});
+
+test('detects abbreviated street address', (t) => {
+  const findings = detector.detect('My home is 45 Oak Road.');
+  t.is(findings.length, 1);
+  t.is(findings[0]?.value, '45 Oak Road.');
+});
+
+test('detects abbreviated ave with period', (t) => {
+  const findings = detector.detect('1600 Pennsylvania Ave. is famous.');
+  t.is(findings.length, 1);
+  t.is(findings[0]?.value, '1600 Pennsylvania Ave.');
+});
+
+test('detects alphanumeric street number', (t) => {
+  const findings = detector.detect('Sherlock lived at 221B Baker St in London.');
+  t.is(findings.length, 1);
+  t.is(findings[0]?.value, '221B Baker St');
+});
+
+test('detects multiple addresses', (t) => {
+  const findings = detector.detect('From 10 Downing St to 1600 Pennsylvania Ave.');
+  t.is(findings.length, 2);
+  t.is(findings[0]?.value, '10 Downing St');
+  t.is(findings[1]?.value, '1600 Pennsylvania Ave.');
+});
+
+// --- Negative Cases ---
+
+test('does not fire on bare numbers', (t) => {
+  const findings = detector.detect('I bought 123 apples.');
+  t.is(findings.length, 0);
+});
+
+test('does not fire on dates', (t) => {
+  const findings = detector.detect('The event is on 2024-01-01 today.');
+  t.is(findings.length, 0);
+});
+
+test('does not fire on version strings', (t) => {
+  const findings = detector.detect('Version 1.2.3 released.');
+  t.is(findings.length, 0);
+});
+
+test('does not fire on plain text', (t) => {
+  const findings = detector.detect('I live down the street from here.');
+  t.is(findings.length, 0);
+});


### PR DESCRIPTION
Closes #28 

## Description

This PR implements the new **AddressDetector** to detect conservative, unambiguous street-shaped postal addresses, fulfilling the requirements of Issue.

### What's included

* Added a new `AddressDetector` (`src/detectors/postal-address.ts`) that detects street addresses consisting of:

  * a street number,
  * one or more street name tokens,
  * a recognized street suffix (e.g. `Street`, `St`, `Road`, `Rd`, `Avenue`, `Ave`, etc.).
* Registered the detector in `DEFAULT_DETECTORS` so it is enabled by default.
* Registered the detector in the collision resolver to ensure deterministic overlap handling.
* Added detector documentation and updated the built-in detector list.
* Added comprehensive unit tests covering positive and negative detection scenarios.
* Added integration tests verifying postal addresses round-trip correctly through `scrub()` → `rehydrate()`.

### Additional infrastructure fix

While implementing this feature, I encountered a test infrastructure regression introduced after the recent AVA 8 upgrade. Enabling `workerThreads` caused the `tsx` loader to fail with `ERR_MODULE_NOT_FOUND`, preventing the test suite from running successfully.

To restore the existing test workflow, this PR disables AVA worker threads in `package.json`. This change only affects the test environment and does **not** impact production behavior.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update
* [x] Refactoring

## Testing Notes

### Automated tests

* Ran `pnpm run test:all`.
* Added unit tests for positive and negative postal address detection.
* Added integration tests covering `scrub()` → `rehydrate()` round-tripping.
* Verified the complete test suite passes successfully.
* Verified coverage remains above the project's target:

  * **Lines:** 94.41%
  * **Statements:** 94.41%
  * **Functions:** 100%
  * **Branches:** 85.9%

### Manual verification

* Verified representative street addresses are replaced with `Address_*` placeholders.
* Verified non-address inputs (e.g. bare numbers, dates, version strings, and ordinary text) are not detected.
* Verified detected addresses are restored correctly during rehydration.

## Checklist

* [x] I have self-reviewed my code.
* [x] I have formatted, linted, and passed all tests (`pnpm run check` / `pnpm run test:all`).
* [x] I have added/updated documentation if necessary.
* [x] I have added/updated tests if necessary.
* [x] I have NOT bumped the version in `package.json` (maintainers will handle this).
