### PR TITLE
feat: add opt-in NameDetector and enable flags

### DIFF
--- a/docs/features/detectors.md
+++ b/docs/features/detectors.md
@@ -35,6 +35,10 @@ export interface Detector {
 - `SecretDetector`: Detects high-entropy strings, API keys, and tokens.
 - `AddressDetector`: Detects unambiguous postal addresses (e.g., street shapes).
 
+### Opt-in Detectors (Off by Default)
+
+- `NameDetector`: Detects proper nouns (capitalized words). Because proper-noun detection has a high risk of false positives, this detector is **disabled by default**. It can be enabled via the API or CLI. It also features a "strict mode" that leverages an allowlist to skip common countries, languages, and products to minimize false positives.
+
 ## Priority & Collision System
 
 When multiple detectors flag overlapping spans, a collision resolution system determines which finding wins.
@@ -46,12 +50,17 @@ Priority is implicitly handled by a defined order of precedence:
 4. `PathDetector`
 5. `PhoneDetector`
 6. `AddressDetector`
+7. `NameDetector`
 
 If `SecretDetector` and `UrlDetector` match the same string (e.g., a URL with a token), `SecretDetector` wins.
 
 ## Registration System
 
-By default, the core scrub function runs the built-in detectors in priority order. You can optionally pass `disabledDetectors` in the `ScrubOptions` to turn off specific built-ins.
+By default, the core scrub function runs the built-in detectors in priority order. You can optionally configure detectors via `ScrubOptions` in the API, or through the CLI:
+
+- **Disable defaults**: Pass `disabledDetectors` (or `--disable` via CLI) to turn off specific built-ins.
+- **Enable opt-ins**: Pass `enabledDetectors` (or `--enable` via CLI) to activate off-by-default detectors like `NameDetector`.
+- **Strict Mode**: Pass `strictNameDetector: true` (or `--strict-name` via CLI) to reduce false positives for the `NameDetector`.
 
 ### Custom Detectors
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 allowBuilds:
   esbuild: set this to true or false
-auditConfig: {}
+auditConfig: { ignoreGhsas: null }

--- a/src/cli/commands/scrub.ts
+++ b/src/cli/commands/scrub.ts
@@ -2,14 +2,20 @@ import type { Command } from 'commander';
 import { readFileSync } from 'node:fs';
 import { scrub } from '../../core/scrub.js';
 
-export function handleScrub(text: string, options: { sessionId?: string; disable?: string }) {
+export function handleScrub(
+  text: string,
+  options: { sessionId?: string; disable?: string; enable?: string; strictName?: boolean },
+) {
   const disabledDetectors = options.disable ? options.disable.split(',').map((s) => s.trim()) : [];
+  const enabledDetectors = options.enable ? options.enable.split(',').map((s) => s.trim()) : [];
 
   const result = scrub({
     content: text,
     ...(options.sessionId ? { sessionId: options.sessionId } : {}),
     options: {
       disabledDetectors,
+      enabledDetectors,
+      ...(options.strictName !== undefined ? { strictNameDetector: options.strictName } : {}),
     },
   });
 
@@ -23,6 +29,14 @@ export function setupScrubCommand(program: Command) {
     .argument('[file]', 'File to scrub. If omitted, reads from stdin.')
     .option('--session-id <id>', 'Resume or target a specific session')
     .option('--disable <detectors>', 'Comma-separated list of detector names to skip')
+    .option(
+      '--enable <detectors>',
+      'Comma-separated list of off-by-default detectors to enable (e.g., NameDetector)',
+    )
+    .option(
+      '--strict-name',
+      'Enable strict allowlisting for NameDetector to reduce false positives',
+    )
     .action((file, options) => {
       let input = '';
 

--- a/src/core/collision-resolver.ts
+++ b/src/core/collision-resolver.ts
@@ -8,6 +8,7 @@ const DETECTOR_PRIORITY: Record<string, number> = {
   PathDetector: 4,
   PhoneDetector: 5,
   AddressDetector: 6,
+  NameDetector: 7,
 };
 
 function priorityOf(finding: Finding): number {

--- a/src/core/scrub.ts
+++ b/src/core/scrub.ts
@@ -7,6 +7,7 @@ import { UrlDetector } from '../detectors/url.js';
 import { PathDetector } from '../detectors/path.js';
 import { SecretDetector } from '../detectors/secret.js';
 import { PostalAddressDetector } from '../detectors/postal-address.js';
+import { NameDetector } from '../detectors/name.js';
 
 const DEFAULT_DETECTORS: Detector[] = [
   new SecretDetector(),
@@ -51,26 +52,39 @@ export function scrub(request: ScrubRequest): ScrubResult {
 
   const session = new SessionManager(sessionId);
 
-  // Build active detector list
-  const disabledSet = new Set(
-    (options?.disabledDetectors ?? []).map((d) => d.toLowerCase().replace('detector', '')),
-  );
-  const activeDetectors = DEFAULT_DETECTORS.filter(
-    (d) => !disabledSet.has(d.name.toLowerCase().replace('detector', '')),
-  );
+  const activeDetectors = [...DEFAULT_DETECTORS];
+
+  if (options?.enabledDetectors) {
+    for (const detectorName of options.enabledDetectors) {
+      if (detectorName === 'NameDetector') {
+        activeDetectors.push(new NameDetector(options?.strictNameDetector));
+      }
+    }
+  }
+
+  let detectors = activeDetectors;
+  if (options?.disabledDetectors) {
+    const disabledSet = new Set(
+      options.disabledDetectors.map((d) => d.toLowerCase().replace('detector', '')),
+    );
+    detectors = detectors.filter(
+      (d) => !disabledSet.has(d.name.toLowerCase().replace('detector', '')),
+    );
+  }
+
   if (options?.customDetectors) {
-    activeDetectors.push(...options.customDetectors);
+    detectors.push(...options.customDetectors);
   }
 
   let scrubbedContent: string | Message[];
 
   if (typeof content === 'string') {
-    scrubbedContent = scrubString(content, activeDetectors, session);
+    scrubbedContent = scrubString(content, detectors, session);
   } else {
     // Message[] — scrub each message's content independently, preserve structure
     scrubbedContent = content.map((msg) => ({
       ...msg,
-      content: scrubString(msg.content, activeDetectors, session),
+      content: scrubString(msg.content, detectors, session),
     }));
   }
 

--- a/src/detectors/name.ts
+++ b/src/detectors/name.ts
@@ -1,0 +1,105 @@
+import type { Detector, Finding } from '../types/index.js';
+
+// Matches words starting with a capital letter, optionally followed by more capitalized words.
+// e.g., "Alice", "John Doe", "San Francisco"
+const NAME_REGEX = /\b[A-Z][a-z]+(?: [A-Z][a-z]+)*\b/g;
+
+// A small built-in allowlist for strict mode covering common first names, countries,
+// languages, and widely recognized product names.
+const ALLOWLIST = new Set([
+  // Common first names
+  'john',
+  'jane',
+  'michael',
+  'sarah',
+  'david',
+  'emily',
+  'james',
+  'jessica',
+  // Countries
+  'united states',
+  'canada',
+  'mexico',
+  'united kingdom',
+  'france',
+  'germany',
+  'japan',
+  'australia',
+  'india',
+  'china',
+  // Languages
+  'english',
+  'spanish',
+  'french',
+  'german',
+  'japanese',
+  'chinese',
+  'hindi',
+  'arabic',
+  // Widely recognized product/company names
+  'apple',
+  'microsoft',
+  'google',
+  'amazon',
+  'meta',
+  'facebook',
+  'twitter',
+  'openai',
+  // Days & Months
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+  'january',
+  'february',
+  'march',
+  'april',
+  'may',
+  'june',
+  'july',
+  'august',
+  'september',
+  'october',
+  'november',
+  'december',
+]);
+
+export class NameDetector implements Detector {
+  readonly name = 'NameDetector';
+  private strict: boolean;
+
+  constructor(strict = false) {
+    this.strict = strict;
+  }
+
+  detect(text: string): Finding[] {
+    const findings: Finding[] = [];
+    let match: RegExpExecArray | null;
+
+    NAME_REGEX.lastIndex = 0;
+
+    while ((match = NAME_REGEX.exec(text)) !== null) {
+      const value = match[0];
+
+      // In strict mode, we skip matches that contain an allowlisted word
+      if (this.strict) {
+        const words = value.toLowerCase().split(' ');
+        if (words.some((w) => ALLOWLIST.has(w))) {
+          continue;
+        }
+      }
+
+      findings.push({
+        category: 'Name',
+        span: [match.index, match.index + value.length],
+        value,
+        placeholderPrefix: 'Name',
+      });
+    }
+
+    return findings;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,8 @@ export interface ScrubRequest {
 export interface ScrubOptions {
   customDetectors?: Detector[];
   disabledDetectors?: string[]; // Array of detector names to skip
+  enabledDetectors?: string[]; // Array of off-by-default detector names to enable
+  strictNameDetector?: boolean; // Enable stricter allowlisting for the NameDetector
 }
 
 export interface ScrubResult {

--- a/tests/cli/scrub.test.ts
+++ b/tests/cli/scrub.test.ts
@@ -20,6 +20,22 @@ test('handleScrub uses provided sessionId', (t) => {
   t.is(result.sessionId, 'test-session-2');
 });
 
+test('handleScrub respects enabled detectors', (t) => {
+  const result = handleScrub('say hello to Alice.', {
+    enable: 'NameDetector',
+  });
+  t.is(result.scrubbedContent, 'say hello to Name_1.');
+});
+
+test('handleScrub respects strictName option', (t) => {
+  const result = handleScrub('Hello John.', {
+    enable: 'NameDetector',
+    strictName: true,
+  });
+  // 'John' is in the allowlist, so it should not be scrubbed in strict mode
+  t.is(result.scrubbedContent, 'Hello John.');
+});
+
 import { setupScrubCommand } from '../../src/cli/commands/scrub.js';
 import { Command } from 'commander';
 

--- a/tests/core/scrub.test.ts
+++ b/tests/core/scrub.test.ts
@@ -170,3 +170,52 @@ test('postal address round-tripping works correctly', (t) => {
 
   t.is(restored.content, text);
 });
+
+test('NameDetector is off by default', (t) => {
+  const text = 'John Doe lives in London.';
+  const scrubbed = scrub({ content: text });
+
+  // NameDetector should not run, so the text should remain unmodified
+  t.is(scrubbed.scrubbedContent, text);
+});
+
+test('NameDetector works when explicitly enabled', (t) => {
+  const text = 'John Doe lives in London.';
+  const scrubbed = scrub({
+    content: text,
+    options: { enabledDetectors: ['NameDetector'] },
+  });
+  t.is(scrubbed.scrubbedContent, 'Name_2 lives in Name_1.');
+});
+
+test('NameDetector works in strict mode', (t) => {
+  // 'John' and 'London' (not in allowlist) vs allowlisted 'France'
+  const text = 'John visited France and London.';
+  const scrubbed = scrub({
+    content: text,
+    options: {
+      enabledDetectors: ['NameDetector'],
+      strictNameDetector: true,
+    },
+  });
+
+  // France is allowlisted, John is allowlisted (wait, 'John' is in allowlist!).
+  // London is not allowlisted.
+  t.is(scrubbed.scrubbedContent, 'John visited France and Name_1.');
+});
+
+test('NameDetector round-trips correctly', (t) => {
+  const text = 'Alice went to Paris.';
+  const scrubbed = scrub({
+    content: text,
+    options: { enabledDetectors: ['NameDetector'] },
+  });
+  t.is(scrubbed.scrubbedContent, 'Name_2 went to Name_1.');
+
+  const restored = rehydrate({
+    content: scrubbed.scrubbedContent as string,
+    sessionId: scrubbed.sessionId,
+  });
+
+  t.is(restored.content, text);
+});

--- a/tests/detectors/name.test.ts
+++ b/tests/detectors/name.test.ts
@@ -1,0 +1,76 @@
+import test from 'ava';
+import { NameDetector } from '../../src/detectors/name.js';
+
+const strictDetector = new NameDetector(true);
+const laxDetector = new NameDetector(false);
+
+// --- Lax Mode (Default) Cases ---
+
+test('detects simple proper noun', (t) => {
+  const findings = laxDetector.detect('say hello to Alice.');
+  t.is(findings.length, 1);
+  t.is(findings[0]?.value, 'Alice');
+  t.is(findings[0]?.placeholderPrefix, 'Name');
+});
+
+test('detects multi-word proper noun', (t) => {
+  const findings = laxDetector.detect('say hello to John Doe.');
+  t.is(findings.length, 1);
+  t.is(findings[0]?.value, 'John Doe');
+});
+
+test('detects allowlisted word in lax mode', (t) => {
+  const findings = laxDetector.detect('I live in the United States.');
+  t.is(findings.length, 1);
+  t.is(findings[0]?.value, 'United States');
+});
+
+test('detects multiple names', (t) => {
+  const findings = laxDetector.detect('Alice and Bob went to London.');
+  t.is(findings.length, 3);
+  t.is(findings[0]?.value, 'Alice');
+  t.is(findings[1]?.value, 'Bob');
+  t.is(findings[2]?.value, 'London');
+});
+
+// --- Strict Mode Cases ---
+
+test('strict mode skips allowlisted first names', (t) => {
+  const findings = strictDetector.detect('John went to the store with Jane.');
+  t.is(findings.length, 0); // John and Jane are allowlisted
+});
+
+test('strict mode skips allowlisted countries and languages', (t) => {
+  const findings = strictDetector.detect('In Canada, people speak English and French.');
+  t.is(findings.length, 0);
+});
+
+test('strict mode skips allowlisted products', (t) => {
+  const findings = strictDetector.detect('Apple and Microsoft are big companies.');
+  t.is(findings.length, 0);
+});
+
+test('strict mode detects non-allowlisted proper nouns', (t) => {
+  const findings = strictDetector.detect('Alice went to Hogwarts.');
+  t.is(findings.length, 2);
+  t.is(findings[0]?.value, 'Alice');
+  t.is(findings[1]?.value, 'Hogwarts');
+});
+
+test('strict mode detects multi-word names even if partial match with allowlist', (t) => {
+  const findings = strictDetector.detect('say hello to Arthur Doe.');
+  t.is(findings.length, 1);
+  t.is(findings[0]?.value, 'Arthur Doe');
+});
+
+// --- Negative Cases ---
+
+test('does not match lowercase words', (t) => {
+  const findings = laxDetector.detect('the quick brown fox');
+  t.is(findings.length, 0);
+});
+
+test('does not match mid-word capital letters', (t) => {
+  const findings = laxDetector.detect('macOS or iPhone');
+  t.is(findings.length, 0);
+});


### PR DESCRIPTION
Closes #29 

## Description

This PR implements an opt-in **NameDetector** for detecting proper nouns, introducing the only built-in detector that is **disabled by default**, as described in Issue.

### What's included

* Added a new `NameDetector` (`src/detectors/name.ts`) capable of detecting likely personal names using a conservative matching strategy.
* Introduced a generic opt-in mechanism for built-in detectors that are disabled by default.
* Extended `ScrubOptions` to support enabling optional detectors and configuring strict mode.
* Registered `NameDetector` in the collision resolver so name findings participate consistently in overlap resolution.
* Added a strict mode with a built-in allowlist to reduce false positives by preserving common first names, countries, languages, and widely recognized product names.
* Added CLI support for enabling the detector via `--enable` and enabling strict mode via `--strict-name`.
* Updated the detector documentation to describe the detector's default-disabled behavior, false-positive trade-offs, and both API and CLI usage.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [x] Documentation update
* [ ] Refactoring

## Testing Notes

### Automated tests

* Ran `pnpm run test:all`.
* Added unit tests covering:

  * detector disabled by default,
  * API opt-in behavior,
  * strict mode allowlist behavior,
  * positive and negative detection cases.
* Added CLI tests verifying `--enable` and `--strict-name` correctly configure the detector.
* Added integration tests verifying `scrub()` → `rehydrate()` correctly round-trips detected names.
* Verified `pnpm run test:coverage` continues to satisfy the project's coverage requirements.

### Manual verification

* Verified the detector remains disabled unless explicitly enabled.
* Verified enabling the detector replaces detected names with `Name_*` placeholders.
* Verified strict mode reduces false positives for allowlisted terms.
* Verified detected names are restored correctly during rehydration.

## Checklist

* [x] I have self-reviewed my code.
* [x] I have formatted, linted, and passed all tests (`pnpm run check` / `pnpm run test:all`).
* [x] I have added/updated documentation if necessary.
* [x] I have added/updated tests if necessary.
* [x] I have NOT bumped the version in `package.json` (maintainers will handle this).
