### PR TITLE
feat: add opt-in CodeTellDetector and enable config options

### DIFF
--- a/docs/features/detectors.md
+++ b/docs/features/detectors.md
@@ -38,6 +38,7 @@ export interface Detector {
 ### Opt-in Detectors (Off by Default)
 
 - `NameDetector`: Detects proper nouns (capitalized words). Because proper-noun detection has a high risk of false positives, this detector is **disabled by default**. It can be enabled via the API or CLI. It also features a "strict mode" that leverages an allowlist to skip common countries, languages, and products to minimize false positives.
+- `CodeTellDetector`: Detects user-enumerated private identifiers and variables. It is **disabled by default** because the false-positive risk of supplying overly generic terms on code payloads is very high. It acts as a no-op unless explicitly configured with a list of terms.
 
 ## Priority & Collision System
 
@@ -51,6 +52,7 @@ Priority is implicitly handled by a defined order of precedence:
 5. `PhoneDetector`
 6. `AddressDetector`
 7. `NameDetector`
+8. `CodeTellDetector`
 
 If `SecretDetector` and `UrlDetector` match the same string (e.g., a URL with a token), `SecretDetector` wins.
 
@@ -61,6 +63,7 @@ By default, the core scrub function runs the built-in detectors in priority orde
 - **Disable defaults**: Pass `disabledDetectors` (or `--disable` via CLI) to turn off specific built-ins.
 - **Enable opt-ins**: Pass `enabledDetectors` (or `--enable` via CLI) to activate off-by-default detectors like `NameDetector`.
 - **Strict Mode**: Pass `strictNameDetector: true` (or `--strict-name` via CLI) to reduce false positives for the `NameDetector`.
+- **Code Tell**: Pass `codeTellTerms` (or `--code-tell-terms` via CLI) as an array of identifiers to enable and configure the `CodeTellDetector`.
 
 ### Custom Detectors
 

--- a/src/cli/commands/scrub.ts
+++ b/src/cli/commands/scrub.ts
@@ -4,10 +4,19 @@ import { scrub } from '../../core/scrub.js';
 
 export function handleScrub(
   text: string,
-  options: { sessionId?: string; disable?: string; enable?: string; strictName?: boolean },
+  options: {
+    sessionId?: string;
+    disable?: string;
+    enable?: string;
+    strictName?: boolean;
+    codeTellTerms?: string;
+  },
 ) {
   const disabledDetectors = options.disable ? options.disable.split(',').map((s) => s.trim()) : [];
   const enabledDetectors = options.enable ? options.enable.split(',').map((s) => s.trim()) : [];
+  const codeTellTerms = options.codeTellTerms
+    ? options.codeTellTerms.split(',').map((s) => s.trim())
+    : undefined;
 
   const result = scrub({
     content: text,
@@ -16,6 +25,7 @@ export function handleScrub(
       disabledDetectors,
       enabledDetectors,
       ...(options.strictName !== undefined ? { strictNameDetector: options.strictName } : {}),
+      ...(codeTellTerms !== undefined ? { codeTellTerms } : {}),
     },
   });
 
@@ -36,6 +46,10 @@ export function setupScrubCommand(program: Command) {
     .option(
       '--strict-name',
       'Enable strict allowlisting for NameDetector to reduce false positives',
+    )
+    .option(
+      '--code-tell-terms <terms>',
+      'Comma-separated list of private identifiers to detect (enables CodeTellDetector)',
     )
     .action((file, options) => {
       let input = '';

--- a/src/core/collision-resolver.ts
+++ b/src/core/collision-resolver.ts
@@ -9,6 +9,7 @@ const DETECTOR_PRIORITY: Record<string, number> = {
   PhoneDetector: 5,
   AddressDetector: 6,
   NameDetector: 7,
+  CodeTellDetector: 8,
 };
 
 function priorityOf(finding: Finding): number {

--- a/src/core/scrub.ts
+++ b/src/core/scrub.ts
@@ -8,6 +8,7 @@ import { PathDetector } from '../detectors/path.js';
 import { SecretDetector } from '../detectors/secret.js';
 import { PostalAddressDetector } from '../detectors/postal-address.js';
 import { NameDetector } from '../detectors/name.js';
+import { CodeTellDetector } from '../detectors/code-tell.js';
 
 const DEFAULT_DETECTORS: Detector[] = [
   new SecretDetector(),
@@ -58,8 +59,18 @@ export function scrub(request: ScrubRequest): ScrubResult {
     for (const detectorName of options.enabledDetectors) {
       if (detectorName === 'NameDetector') {
         activeDetectors.push(new NameDetector(options?.strictNameDetector));
+      } else if (detectorName === 'CodeTellDetector') {
+        activeDetectors.push(new CodeTellDetector(options?.codeTellTerms));
       }
     }
+  }
+
+  if (
+    options?.codeTellTerms &&
+    options.codeTellTerms.length > 0 &&
+    !options?.enabledDetectors?.includes('CodeTellDetector')
+  ) {
+    activeDetectors.push(new CodeTellDetector(options.codeTellTerms));
   }
 
   let detectors = activeDetectors;

--- a/src/detectors/code-tell.ts
+++ b/src/detectors/code-tell.ts
@@ -1,0 +1,46 @@
+import type { Detector, Finding } from '../types/index.js';
+
+function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export class CodeTellDetector implements Detector {
+  readonly name = 'CodeTellDetector';
+  private regex: RegExp | null = null;
+
+  constructor(terms: string[] = []) {
+    const validTerms = terms.map((t) => t.trim()).filter((t) => t.length > 0);
+
+    if (validTerms.length > 0) {
+      const sortedTerms = [...validTerms].sort((a, b) => b.length - a.length);
+      const escapedTerms = sortedTerms.map(escapeRegExp);
+
+      const pattern = `(?<![a-zA-Z0-9_$])(?:${escapedTerms.join('|')})(?![a-zA-Z0-9_$])`;
+      this.regex = new RegExp(pattern, 'g');
+    }
+  }
+
+  detect(text: string): Finding[] {
+    if (!this.regex) {
+      return [];
+    }
+
+    const findings: Finding[] = [];
+    let match: RegExpExecArray | null;
+
+    this.regex.lastIndex = 0;
+
+    while ((match = this.regex.exec(text)) !== null) {
+      const value = match[0];
+
+      findings.push({
+        category: 'CodeTell',
+        span: [match.index, match.index + value.length],
+        value,
+        placeholderPrefix: 'CodeTell',
+      });
+    }
+
+    return findings;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,6 +32,7 @@ export interface ScrubOptions {
   disabledDetectors?: string[]; // Array of detector names to skip
   enabledDetectors?: string[]; // Array of off-by-default detector names to enable
   strictNameDetector?: boolean; // Enable stricter allowlisting for the NameDetector
+  codeTellTerms?: string[]; // User-enumerated private identifiers (classes, variables)
 }
 
 export interface ScrubResult {

--- a/tests/cli/scrub.test.ts
+++ b/tests/cli/scrub.test.ts
@@ -36,6 +36,13 @@ test('handleScrub respects strictName option', (t) => {
   t.is(result.scrubbedContent, 'Hello John.');
 });
 
+test('handleScrub respects codeTellTerms', (t) => {
+  const result = handleScrub('const myVar = 1;', {
+    codeTellTerms: 'myVar, otherVar',
+  });
+  t.is(result.scrubbedContent, 'const CodeTell_1 = 1;');
+});
+
 import { setupScrubCommand } from '../../src/cli/commands/scrub.js';
 import { Command } from 'commander';
 

--- a/tests/core/scrub.test.ts
+++ b/tests/core/scrub.test.ts
@@ -219,3 +219,24 @@ test('NameDetector round-trips correctly', (t) => {
 
   t.is(restored.content, text);
 });
+
+test('CodeTellDetector is a no-op by default', (t) => {
+  const text = 'const instance = new SecretClass();';
+  const scrubbed = scrub({ content: text });
+  t.is(scrubbed.scrubbedContent, text);
+});
+
+test('CodeTellDetector runs when terms are provided and round-trips correctly', (t) => {
+  const text = 'const instance = new SecretClass();';
+  const scrubbed = scrub({
+    content: text,
+    options: { codeTellTerms: ['SecretClass'] },
+  });
+  t.is(scrubbed.scrubbedContent, 'const instance = new CodeTell_1();');
+
+  const restored = rehydrate({
+    content: scrubbed.scrubbedContent as string,
+    sessionId: scrubbed.sessionId,
+  });
+  t.is(restored.content, text);
+});

--- a/tests/detectors/code-tell.test.ts
+++ b/tests/detectors/code-tell.test.ts
@@ -1,0 +1,56 @@
+import test from 'ava';
+import { CodeTellDetector } from '../../src/detectors/code-tell.js';
+
+test('no-op when instantiated without terms', (t) => {
+  const detector = new CodeTellDetector();
+  const findings = detector.detect('MyClass is a private class.');
+  t.is(findings.length, 0);
+});
+
+test('no-op when instantiated with empty terms', (t) => {
+  const detector = new CodeTellDetector(['', '   ']);
+  const findings = detector.detect('MyClass is a private class.');
+  t.is(findings.length, 0);
+});
+
+test('detects configured terms', (t) => {
+  const detector = new CodeTellDetector(['MyClass', 'internalVariable']);
+  const findings = detector.detect('The MyClass uses internalVariable for state.');
+  t.is(findings.length, 2);
+  t.is(findings[0]?.value, 'MyClass');
+  t.is(findings[0]?.placeholderPrefix, 'CodeTell');
+  t.is(findings[1]?.value, 'internalVariable');
+});
+
+test('does not match partial tokens', (t) => {
+  const detector = new CodeTellDetector(['Class', 'var']);
+  const findings = detector.detect('MyClass uses a variable.');
+  t.is(findings.length, 0);
+});
+
+test('matches identifiers even if adjacent to non-identifier symbols', (t) => {
+  const detector = new CodeTellDetector(['MyClass']);
+  const findings = detector.detect('new MyClass();');
+  t.is(findings.length, 1);
+  t.is(findings[0]?.value, 'MyClass');
+});
+
+test('escapes regex metacharacters in configured terms', (t) => {
+  const detector = new CodeTellDetector(['foo.bar', '$cache', '__internal__']);
+
+  let findings = detector.detect('fooXbar');
+  t.is(findings.length, 0);
+
+  findings = detector.detect('const c = foo.bar + $cache - __internal__;');
+  t.is(findings.length, 3);
+  t.is(findings[0]?.value, 'foo.bar');
+  t.is(findings[1]?.value, '$cache');
+  t.is(findings[2]?.value, '__internal__');
+});
+
+test('prioritizes longer overlapping terms', (t) => {
+  const detector = new CodeTellDetector(['foo', 'foo.bar']);
+  const findings = detector.detect('Call foo.bar()');
+  t.is(findings.length, 1);
+  t.is(findings[0]?.value, 'foo.bar');
+});


### PR DESCRIPTION
## Summary

This PR implements the opt-in `CodeTellDetector`, completing Issue #30.

The detector identifies user-enumerated private identifiers (such as internal class names and variable conventions) and integrates with the existing scrubbing pipeline while remaining disabled by default to minimize false positives on source code.

## What Changed

### CodeTellDetector

Added a new `CodeTellDetector` implementing the shared `Detector` interface.

Key behaviors:

* Detects only user-configured identifiers.
* Escapes configured terms before compiling the matcher to safely handle regex metacharacters.
* Uses identifier-aware boundary checks to ensure only exact identifiers are matched.
* Emits findings using the `CodeTell` category with the `CodeTell_N` placeholder convention.

### Configuration

Extended `ScrubOptions` with support for:

* `codeTellTerms?: string[]`

The detector remains opt-in and is only activated when explicitly enabled with configured terms.

### CLI Integration

Added support for configuring CodeTell terms through the existing CLI so user-supplied identifiers can be passed into the scrubbing pipeline.

### Collision Resolution

Registered the `CodeTellDetector` in the collision resolver with the appropriate detector priority.

### Testing

Added dedicated test coverage for:

* Configured identifier matching.
* Partial-token rejection.
* Arbitrary code token rejection.
* No-op behavior when no terms are configured.
* Overlapping configured identifiers.
* Identifiers containing regex metacharacters.
* End-to-end `scrub()` → `rehydrate()` round-trip behavior.

### Documentation

Updated the detector documentation to:

* Describe the `CodeTellDetector`.
* Explain its opt-in configuration.
* Document the false-positive trade-offs when supplying overly generic identifiers.

## Results

* 189 passing tests.
* Lint and formatting passing.
* `CodeTellDetector` is disabled by default and only runs when explicitly configured.
* Fully satisfies the acceptance criteria for Issue #30.
