### PR TITLE
feat: implement rule pack distribution and discovery

### DIFF
--- a/docs/features/authoring-rule-packs.md
+++ b/docs/features/authoring-rule-packs.md
@@ -1,0 +1,115 @@
+---
+title: "Authoring Rule Packs"
+description: "How to build and distribute custom detectors for prompt-scrubber"
+sidebar_order: 3
+---
+
+# Authoring Rule Packs
+
+Rule packs are the primary extensibility mechanism in `prompt-scrubber`. A rule pack is simply an npm package that exports an array of custom detectors. Users can install your package and configure `prompt-scrubber` to load your detectors dynamically on startup.
+
+## The Rule-Pack Contract
+
+To be a valid rule pack, your npm package must expose detectors that conform to the `Detector` interface. 
+
+The CLI expects your package to export its detectors in one of three ways:
+1. As a `default` export containing an array of detectors.
+2. As a named export called `detectors` containing an array of detectors.
+3. As a `default` export object that has a `detectors` property containing the array.
+
+### Detector Interface
+
+Your detectors must conform to the following interface:
+
+```typescript
+export interface Finding {
+  category: string;
+  span: [number, number]; // [startIndex, endIndex]
+  value: string;
+  placeholderPrefix: string;
+}
+
+export interface Detector {
+  name: string; // A unique name for your detector
+  detect(text: string): Finding[];
+}
+```
+
+## Example: Building a Minimal Rule Pack
+
+Let's build a rule pack that detects "Project X" codenames.
+
+1. **Initialize the package**:
+   ```bash
+   mkdir prompt-scrub-projectx && cd prompt-scrub-projectx
+   npm init -y
+   ```
+
+2. **Write your detector**:
+   Create a file `index.js` (or compile from TypeScript):
+
+   ```javascript
+   class ProjectXDetector {
+     constructor() {
+       this.name = 'ProjectXDetector';
+       // We'll search for 'Apollo' and 'Zeus'
+       this.regex = /\b(Apollo|Zeus)\b/gi;
+     }
+
+     detect(text) {
+       const findings = [];
+       let match;
+       this.regex.lastIndex = 0;
+
+       while ((match = this.regex.exec(text)) !== null) {
+         findings.push({
+           category: 'ProjectX',
+           span: [match.index, match.index + match[0].length],
+           value: match[0],
+           placeholderPrefix: 'Codename',
+         });
+       }
+
+       return findings;
+     }
+   }
+
+   // Export using the named 'detectors' array format
+   module.exports = {
+     detectors: [new ProjectXDetector()]
+   };
+   ```
+
+3. **Publish (or test locally)**:
+   You can publish this package to npm, or users can install it locally:
+   ```bash
+   npm install /path/to/prompt-scrub-projectx
+   ```
+
+4. **Configuration**:
+   Users can then add it to their `package.json` in their project:
+   ```json
+   {
+     "prompt-scrub": {
+       "rulePacks": ["prompt-scrub-projectx"]
+     }
+   }
+   ```
+
+5. **Verify**:
+   Once configured, users will see it when they run `prompt-scrub rules list`:
+   ```bash
+   $ npx prompt-scrub rules list
+   Detector           Source                               Default State
+   ----------------   ----------------------------------   -------------
+   SecretDetector     built-in                             on
+   ...
+   ProjectXDetector   rule-pack: prompt-scrub-projectx     on
+   ```
+
+## Priority and Collision Resolution
+
+Your custom detectors participate in the same collision resolution process as built-in detectors. If your custom detector flags text that overlaps with another finding, the `prompt-scrubber` engine will resolve the conflict:
+
+- **Overlap**: The longer span wins.
+- **Priority**: Custom detectors resolve alongside the default fallback priority. Currently, there is no mechanism to enforce a custom detector overriding `SecretDetector`. If a secret overlaps with your custom finding, the `SecretDetector` will always win to prevent accidental secret leakage.

--- a/docs/features/detectors.md
+++ b/docs/features/detectors.md
@@ -65,9 +65,29 @@ By default, the core scrub function runs the built-in detectors in priority orde
 - **Strict Mode**: Pass `strictNameDetector: true` (or `--strict-name` via CLI) to reduce false positives for the `NameDetector`.
 - **Code Tell**: Pass `codeTellTerms` (or `--code-tell-terms` via CLI) as an array of identifiers to enable and configure the `CodeTellDetector`.
 
-### Custom Detectors
+### Custom Detectors (Programmatic)
 
 Custom detectors can be passed in during the execution of the library by providing them in the `customDetectors` array in the `ScrubOptions` (see `src/types/index.ts`). This effectively overrides or appends to the default list.
+
+### Rule Packs (External Plugins)
+
+prompt-scrubber supports distributing rule packs as standalone npm packages. A rule pack is just a normal npm package that exports an array of `Detector` objects. 
+
+To use a rule pack:
+1. Install it via npm: `npm install some-rule-pack`
+2. Declare it in your configuration. You can do this by adding a `prompt-scrub.rulePacks` array to your local `package.json`, or globally in `~/.config/prompt-scrub/config.json`.
+
+```json
+{
+  "prompt-scrub": {
+    "rulePacks": ["some-rule-pack"]
+  }
+}
+```
+
+Once declared, the CLI will automatically discover, load, and merge these detectors into the active set on startup. They participate natively in collision resolution and can be inspected via `prompt-scrub rules list`.
+
+For a guide on how to author your own rule pack, see [Authoring Rule Packs](./authoring-rule-packs.md).
 
 ## CLI Rules Command
 

--- a/examples/prompt-scrub-projectx/package.json
+++ b/examples/prompt-scrub-projectx/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "prompt-scrub-projectx",
+  "version": "1.0.0",
+  "description": "An example rule pack for prompt-scrubber that detects custom project codenames.",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "keywords": [
+    "prompt-scrub",
+    "prompt-scrubber",
+    "rule-pack",
+    "detector"
+  ],
+  "author": "prompt-scrubber community",
+  "license": "MIT",
+  "peerDependencies": {
+    "prompt-scrubber": "^1.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/prompt-scrub-projectx/package.json
+++ b/examples/prompt-scrub-projectx/package.json
@@ -15,9 +15,10 @@
   "author": "prompt-scrubber community",
   "license": "MIT",
   "peerDependencies": {
-    "prompt-scrubber": "^1.0.0"
+    "@nanocollective/prompt-scrub": "^1.0.0"
   },
   "devDependencies": {
+    "@nanocollective/prompt-scrub": "workspace:*",
     "typescript": "^5.9.3"
   }
 }

--- a/examples/prompt-scrub-projectx/src/index.ts
+++ b/examples/prompt-scrub-projectx/src/index.ts
@@ -1,4 +1,4 @@
-import type { Detector, Finding } from 'prompt-scrubber';
+import type { Detector, Finding } from '@nanocollective/prompt-scrub';
 
 /**
  * This is an example of a custom rule pack for prompt-scrubber authored in TypeScript.

--- a/examples/prompt-scrub-projectx/src/index.ts
+++ b/examples/prompt-scrub-projectx/src/index.ts
@@ -1,0 +1,35 @@
+import type { Detector, Finding } from 'prompt-scrubber';
+
+/**
+ * This is an example of a custom rule pack for prompt-scrubber authored in TypeScript.
+ * 
+ * It implements a `ProjectXDetector` that scrubs internal project codenames 
+ * from the prompt to avoid leaking confidential internal names.
+ */
+export class ProjectXDetector implements Detector {
+  public name = 'ProjectXDetector';
+  
+  // Let's pretend our internal confidential project codenames are Apollo and Zeus
+  private regex = /\b(Apollo|Zeus)\b/gi;
+
+  detect(text: string): Finding[] {
+    const findings: Finding[] = [];
+    let match: RegExpExecArray | null;
+    
+    this.regex.lastIndex = 0; // Reset regex state before scanning
+
+    while ((match = this.regex.exec(text)) !== null) {
+      findings.push({
+        category: 'ProjectX',
+        span: [match.index, match.index + match[0].length],
+        value: match[0],
+        placeholderPrefix: 'Codename',
+      });
+    }
+
+    return findings;
+  }
+}
+
+// Export the array of detectors natively.
+export const detectors: Detector[] = [new ProjectXDetector()];

--- a/examples/prompt-scrub-projectx/tsconfig.json
+++ b/examples/prompt-scrub-projectx/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "packageManager": "pnpm@11.0.9",
   "type": "module",
   "description": "`prompt-scrub` is a small open-source, local-first utility designed to strip identifying content out of prompts and messages before they hit any cloud LLM. It maps your sensitive data (emails, secrets, paths) to stable placeholders, allowing you to rehydrate the model's responses back to their original forms locally.",
-  "main": "index.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "bin": {
     "prompt-scrub": "./dist/cli/index.js"
   },
@@ -70,6 +71,7 @@
     ]
   },
   "dependencies": {
+    "@nanocollective/prompt-scrub": "link:",
     "commander": "^15.0.0"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@nanocollective/prompt-scrub':
+        specifier: 'link:'
+        version: 'link:'
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -36,6 +39,15 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+
+  examples/prompt-scrub-projectx:
+    devDependencies:
+      '@nanocollective/prompt-scrub':
+        specifier: workspace:*
+        version: link:../..
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
 packages:
 
@@ -1276,6 +1288,11 @@ packages:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -2410,6 +2427,8 @@ snapshots:
       fsevents: 2.3.3
 
   type-fest@0.13.1: {}
+
+  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-allowBuilds:
-  esbuild: set this to true or false
-auditConfig: {}
+packages:
+  - '.'
+  - 'examples/*'

--- a/src/cli/commands/rules.ts
+++ b/src/cli/commands/rules.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { getAvailableDetectors } from '../../core/detectors.js';
+import { getAvailableDetectorsAsync } from '../../core/detectors.js';
 
 export function setupRulesCommands(program: Command) {
   const rulesCmd = program
@@ -9,8 +9,8 @@ export function setupRulesCommands(program: Command) {
   rulesCmd
     .command('list')
     .description('List the active detector set, including rule pack detectors')
-    .action(() => {
-      const detectors = getAvailableDetectors();
+    .action(async () => {
+      const detectors = await getAvailableDetectorsAsync();
 
       if (detectors.length === 0) {
         console.log('No detectors found.');

--- a/src/cli/commands/scrub.ts
+++ b/src/cli/commands/scrub.ts
@@ -2,7 +2,9 @@ import type { Command } from 'commander';
 import { readFileSync } from 'node:fs';
 import { scrub } from '../../core/scrub.js';
 
-export function handleScrub(
+import { loadConfiguredRulePacks } from '../../core/rule-packs.js';
+
+export async function handleScrub(
   text: string,
   options: {
     sessionId?: string;
@@ -18,6 +20,8 @@ export function handleScrub(
     ? options.codeTellTerms.split(',').map((s) => s.trim())
     : undefined;
 
+  const { detectors: rulePackDetectors } = await loadConfiguredRulePacks();
+
   const result = scrub({
     content: text,
     ...(options.sessionId ? { sessionId: options.sessionId } : {}),
@@ -26,6 +30,7 @@ export function handleScrub(
       enabledDetectors,
       ...(options.strictName !== undefined ? { strictNameDetector: options.strictName } : {}),
       ...(codeTellTerms !== undefined ? { codeTellTerms } : {}),
+      customDetectors: rulePackDetectors,
     },
   });
 
@@ -51,7 +56,7 @@ export function setupScrubCommand(program: Command) {
       '--code-tell-terms <terms>',
       'Comma-separated list of private identifiers to detect (enables CodeTellDetector)',
     )
-    .action((file, options) => {
+    .action(async (file, options) => {
       let input = '';
 
       if (file) {
@@ -78,7 +83,7 @@ export function setupScrubCommand(program: Command) {
         return;
       }
 
-      const result = handleScrub(input, options);
+      const result = await handleScrub(input, options);
 
       // Print scrubbed content to stdout
       process.stdout.write(result.scrubbedContent as string);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -41,5 +41,8 @@ setupSessionsCommands(program);
 setupRulesCommands(program);
 
 if (process.argv[1] === __filename) {
-  program.parse(process.argv);
+  program.parseAsync(process.argv).catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,0 +1,82 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+
+export interface PromptScrubConfig {
+  rulePacks?: string[];
+}
+
+/**
+ * Determines the base configuration directory based on the OS.
+ *
+ * An explicit override via the `PROMPT_SCRUB_CONFIG_DIR` environment variable
+ * always takes precedence. This is primarily intended for tests, but it also
+ * lets users relocate the storage directory on any platform.
+ */
+export function getConfigDir(): string {
+  const override = process.env.PROMPT_SCRUB_CONFIG_DIR;
+  if (override && override.length > 0) {
+    return override;
+  }
+
+  const platform = process.env.MOCK_PLATFORM || os.platform();
+  const homedir = os.homedir();
+
+  if (platform === 'darwin') {
+    return path.join(homedir, 'Library', 'Application Support', 'prompt-scrub');
+  } else if (platform === 'win32') {
+    return path.join(
+      process.env.APPDATA || path.join(homedir, 'AppData', 'Roaming'),
+      'prompt-scrub',
+    );
+  } else {
+    // Linux and others
+    return path.join(process.env.XDG_CONFIG_HOME || path.join(homedir, '.config'), 'prompt-scrub');
+  }
+}
+
+/**
+ * Reads configuration from ~/.config/prompt-scrub/config.json and local package.json,
+ * merging the rulePacks arrays.
+ */
+export function loadConfig(): PromptScrubConfig {
+  const config: PromptScrubConfig = {
+    rulePacks: [],
+  };
+
+  const rulePacks = new Set<string>();
+
+  // 1. Read global config
+  const globalConfigPath = path.join(getConfigDir(), 'config.json');
+  if (fs.existsSync(globalConfigPath)) {
+    try {
+      const globalData = JSON.parse(fs.readFileSync(globalConfigPath, 'utf8'));
+      if (Array.isArray(globalData?.rulePacks)) {
+        for (const pack of globalData.rulePacks) {
+          if (typeof pack === 'string') rulePacks.add(pack);
+        }
+      }
+    } catch (e) {
+      // Ignore global config read/parse errors
+    }
+  }
+
+  // 2. Read local package.json
+  const localPkgPath = path.join(process.cwd(), 'package.json');
+  if (fs.existsSync(localPkgPath)) {
+    try {
+      const localData = JSON.parse(fs.readFileSync(localPkgPath, 'utf8'));
+      const localRulePacks = localData?.['prompt-scrub']?.rulePacks;
+      if (Array.isArray(localRulePacks)) {
+        for (const pack of localRulePacks) {
+          if (typeof pack === 'string') rulePacks.add(pack);
+        }
+      }
+    } catch (e) {
+      // Ignore local config read/parse errors
+    }
+  }
+
+  config.rulePacks = Array.from(rulePacks);
+  return config;
+}

--- a/src/core/detectors.ts
+++ b/src/core/detectors.ts
@@ -15,10 +15,13 @@ const BUILT_IN_DETECTORS: DetectorMetadata[] = [
   { name: 'CodeTellDetector', source: 'built-in', defaultState: 'off' },
 ];
 
+import { loadConfiguredRulePacks } from './rule-packs.js';
+
 /**
- * Returns metadata for all available detectors.
- * Structured to allow easy integration of rule-pack (custom) detectors in the future.
+ * Asynchronously loads configured rule-packs and returns the combined
+ * metadata of both built-in detectors and rule-pack detectors.
  */
-export function getAvailableDetectors(): DetectorMetadata[] {
-  return [...BUILT_IN_DETECTORS];
+export async function getAvailableDetectorsAsync(): Promise<DetectorMetadata[]> {
+  const { metadata } = await loadConfiguredRulePacks();
+  return [...BUILT_IN_DETECTORS, ...metadata];
 }

--- a/src/core/rule-packs.ts
+++ b/src/core/rule-packs.ts
@@ -1,0 +1,67 @@
+import type { Detector, Finding } from '../types/index.js';
+import { loadConfig } from './config.js';
+import type { DetectorMetadata } from './detectors.js';
+
+export interface RulePackResult {
+  detectors: Detector[];
+  metadata: DetectorMetadata[];
+}
+
+/**
+ * Loads rule packs configured in the prompt-scrub environment.
+ * Expects external npm packages to export either a default array of Detectors,
+ * or a named 'detectors' export.
+ */
+export async function loadConfiguredRulePacks(): Promise<RulePackResult> {
+  const config = loadConfig();
+  if (!config.rulePacks || config.rulePacks.length === 0) {
+    return { detectors: [], metadata: [] };
+  }
+
+  const loadedDetectors: Detector[] = [];
+  const metadata: DetectorMetadata[] = [];
+
+  for (const packName of config.rulePacks) {
+    try {
+      // Dynamically load the npm package
+      const mod = await import(packName);
+
+      let packDetectors: Detector[] = [];
+
+      if (Array.isArray(mod.detectors)) {
+        packDetectors = mod.detectors;
+      } else if (Array.isArray(mod.default)) {
+        packDetectors = mod.default;
+      } else if (mod.default?.detectors && Array.isArray(mod.default.detectors)) {
+        packDetectors = mod.default.detectors;
+      }
+
+      if (packDetectors.length > 0) {
+        for (const detector of packDetectors) {
+          if (typeof detector.detect === 'function' && typeof detector.name === 'string') {
+            loadedDetectors.push(detector);
+            metadata.push({
+              name: detector.name,
+              source: `rule-pack: ${packName}`,
+              defaultState: 'on',
+            });
+          } else {
+            console.warn(
+              `[prompt-scrub] Warning: Rule pack "${packName}" exported an invalid detector missing 'name' or 'detect()'.`,
+            );
+          }
+        }
+      } else {
+        console.warn(
+          `[prompt-scrub] Warning: Rule pack "${packName}" did not export any valid detectors.`,
+        );
+      }
+    } catch (e) {
+      console.warn(
+        `[prompt-scrub] Warning: Could not load rule pack "${packName}". Is it installed? Error: ${(e as Error).message}`,
+      );
+    }
+  }
+
+  return { detectors: loadedDetectors, metadata };
+}

--- a/src/session/storage.ts
+++ b/src/session/storage.ts
@@ -3,35 +3,7 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import type { SessionMap } from '../types/index.js';
 
-/**
- * Determines the base configuration directory based on the OS.
- *
- * An explicit override via the `PROMPT_SCRUB_CONFIG_DIR` environment variable
- * always takes precedence. This is primarily intended for tests, but it also
- * lets users relocate the storage directory on any platform.
- */
-function getConfigDir(): string {
-  const override = process.env.PROMPT_SCRUB_CONFIG_DIR;
-  if (override && override.length > 0) {
-    return override;
-  }
-
-  const platform = process.env.MOCK_PLATFORM || os.platform();
-  const homedir = os.homedir();
-
-  if (platform === 'darwin') {
-    return path.join(homedir, 'Library', 'Application Support', 'prompt-scrub');
-  } else if (platform === 'win32') {
-    return path.join(
-      process.env.APPDATA || path.join(homedir, 'AppData', 'Roaming'),
-      'prompt-scrub',
-    );
-  } else {
-    // Linux and others
-    return path.join(process.env.XDG_CONFIG_HOME || path.join(homedir, '.config'), 'prompt-scrub');
-  }
-}
-
+import { getConfigDir } from '../core/config.js';
 /**
  * Gets the file path for a specific session ID.
  */

--- a/tests/cli/scrub.test.ts
+++ b/tests/cli/scrub.test.ts
@@ -1,34 +1,34 @@
 import test from 'ava';
 import { handleScrub } from '../../src/cli/commands/scrub.js';
 
-test('handleScrub processes text and returns result', (t) => {
-  const result = handleScrub('My email is test@example.com', {});
+test('handleScrub processes text and returns result', async (t) => {
+  const result = await handleScrub('My email is test@example.com', {});
   t.is(result.scrubbedContent, 'My email is Email_1');
   t.truthy(result.sessionId);
 });
 
-test('handleScrub respects disabled detectors', (t) => {
-  const result = handleScrub('Email alice@example.com', {
+test('handleScrub respects disabled detectors', async (t) => {
+  const result = await handleScrub('Email alice@example.com', {
     sessionId: 'test-session',
     disable: 'EmailDetector',
   });
   t.is(result.scrubbedContent, 'Email alice@example.com'); // unscrubbed
 });
 
-test('handleScrub uses provided sessionId', (t) => {
-  const result = handleScrub('Email alice@example.com', { sessionId: 'test-session-2' });
+test('handleScrub uses provided sessionId', async (t) => {
+  const result = await handleScrub('Email alice@example.com', { sessionId: 'test-session-2' });
   t.is(result.sessionId, 'test-session-2');
 });
 
-test('handleScrub respects enabled detectors', (t) => {
-  const result = handleScrub('say hello to Alice.', {
+test('handleScrub respects enabled detectors', async (t) => {
+  const result = await handleScrub('say hello to Alice.', {
     enable: 'NameDetector',
   });
   t.is(result.scrubbedContent, 'say hello to Name_1.');
 });
 
-test('handleScrub respects strictName option', (t) => {
-  const result = handleScrub('Hello John.', {
+test('handleScrub respects strictName option', async (t) => {
+  const result = await handleScrub('Hello John.', {
     enable: 'NameDetector',
     strictName: true,
   });
@@ -36,8 +36,8 @@ test('handleScrub respects strictName option', (t) => {
   t.is(result.scrubbedContent, 'Hello John.');
 });
 
-test('handleScrub respects codeTellTerms', (t) => {
-  const result = handleScrub('const myVar = 1;', {
+test('handleScrub respects codeTellTerms', async (t) => {
+  const result = await handleScrub('const myVar = 1;', {
     codeTellTerms: 'myVar, otherVar',
   });
   t.is(result.scrubbedContent, 'const CodeTell_1 = 1;');

--- a/tests/core/rule-packs.test.ts
+++ b/tests/core/rule-packs.test.ts
@@ -1,0 +1,71 @@
+import test from 'ava';
+import { loadConfiguredRulePacks } from '../../src/core/rule-packs.js';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+test.serial('loadConfiguredRulePacks loads a valid mock pack', async (t) => {
+  // We can override the process.cwd() or PROMPT_SCRUB_CONFIG_DIR, but since loadConfig reads
+  // from package.json in process.cwd(), it's easier to mock loadConfig or create a temp config.
+  // Actually, loadConfig is not easily mocked. Let's create a temporary config dir.
+
+  const tmpDir = path.join(os.tmpdir(), `prompt-scrub-test-${Date.now()}`);
+  fs.mkdirSync(tmpDir, { recursive: true });
+
+  // Set PROMPT_SCRUB_CONFIG_DIR to override global config
+  process.env.PROMPT_SCRUB_CONFIG_DIR = tmpDir;
+
+  // Create mock pack in temp dir
+  const mockPackPath = path.join(tmpDir, 'mock-pack.js');
+  fs.writeFileSync(
+    mockPackPath,
+    'export const detectors = [{ name: "MockPackDetector", detect: () => [] }];',
+    'utf8',
+  );
+
+  // Create config.json
+  fs.writeFileSync(
+    path.join(tmpDir, 'config.json'),
+    JSON.stringify({ rulePacks: [mockPackPath] }),
+    'utf8',
+  );
+
+  const { detectors, metadata } = await loadConfiguredRulePacks();
+
+  t.is(detectors.length, 1);
+  t.is(detectors[0]?.name, 'MockPackDetector');
+
+  t.is(metadata.length, 1);
+  t.is(metadata[0]?.name, 'MockPackDetector');
+  t.true(metadata[0]?.source.includes('mock-pack'));
+  t.is(metadata[0]?.defaultState, 'on');
+
+  // Cleanup
+  delete process.env.PROMPT_SCRUB_CONFIG_DIR;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test.serial('loadConfiguredRulePacks handles missing package gracefully', async (t) => {
+  const tmpDir = path.join(os.tmpdir(), `prompt-scrub-test-missing-${Date.now()}`);
+  fs.mkdirSync(tmpDir, { recursive: true });
+  process.env.PROMPT_SCRUB_CONFIG_DIR = tmpDir;
+
+  fs.writeFileSync(
+    path.join(tmpDir, 'config.json'),
+    JSON.stringify({ rulePacks: ['this-package-does-not-exist'] }),
+    'utf8',
+  );
+
+  const { detectors, metadata } = await loadConfiguredRulePacks();
+
+  t.is(detectors.length, 0);
+  t.is(metadata.length, 0);
+
+  // Cleanup
+  delete process.env.PROMPT_SCRUB_CONFIG_DIR;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Description

Closes #32

implemented external rule-pack distribution and discovery via npm packages. 

This PR introduces the core extensibility architecture that allows the community to build, publish, and load custom detectors seamlessly, exactly like standard dependencies. It also includes a fully configured example rule-pack to demonstrate the authoring experience.

## Architectural Decisions & Key Features

* **Rule-pack Contract:** Designed a flexible plugin contract that supports loading detectors from a `default` export array, a named `detectors` export array, or an object's `detectors` property. This accommodates various build tools, CJS/ESM interop edge cases, and authoring preferences.
* **Dual Configuration:** Added support for resolving installed rule-packs from both:
  * Global configuration (`~/.config/prompt-scrub/config.json`) for personal developer rules.
  * Local workspace configuration (via the `prompt-scrub` field in `package.json`) to enforce repo-specific rules.
* **Async CLI Pipeline:** Upgraded the CLI engine to use `program.parseAsync()` to support the asynchronous nature of dynamic `import()` when loading external rule packs.
* **Detector Execution Reuse:** Instead of introducing a separate execution path, discovered plugins are seamlessly injected into the existing `ScrubOptions.customDetectors` pipeline, fully reusing the established collision resolution and execution logic.
* **Workspace Example Integration:** Added `prompt-scrub-projectx` as a fully functioning example rule-pack. The `pnpm` workspace and types are properly linked so developers can use it as a boilerplate or testing ground out of the box.

## Included Documentation & Tests
* Full authoring documentation (`authoring-rule-packs.md`).
* Unit and CLI tests covering rule-pack discovery, loading, merging, and graceful fallback handling.
