### PR TITLE
feat: support Message[] input in rehydrate

### DIFF
--- a/src/cli/commands/rehydrate.ts
+++ b/src/cli/commands/rehydrate.ts
@@ -46,7 +46,8 @@ export function setupRehydrateCommand(program: Command) {
       const result = handleRehydrate(input, options);
 
       // Print rehydrated content to stdout
-      process.stdout.write(result.content);
+      const outStr = typeof result.content === 'string' ? result.content : JSON.stringify(result.content, null, 2);
+      process.stdout.write(outStr);
 
       // Print any warnings to stderr
       if (result.warnings && result.warnings.length > 0) {

--- a/src/core/rehydrate.ts
+++ b/src/core/rehydrate.ts
@@ -1,23 +1,9 @@
-import type { RehydrateRequest, RehydrateResult } from '../types/index.js';
+import type { RehydrateRequest, RehydrateResult, Message } from '../types/index.js';
 import { readSessionMap } from '../session/storage.js';
 
 const PLACEHOLDER_REGEX = /\b([A-Za-z]+_\d+)\b/g;
 
-/**
- * Restores original values from placeholders in the given content string,
- * using the session map identified by sessionId.
- *
- * - Known placeholders are replaced with their originalValue.
- * - Unknown placeholders (hallucinated by the LLM) are left as-is and a
- *   warning is added to the result.
- *
- * Placeholders are replaced longest-first to prevent partial replacements
- * (e.g. Email_10 being corrupted to Email_1<remaining-0>).
- */
-export function rehydrate(request: RehydrateRequest): RehydrateResult {
-  const { content, sessionId } = request;
-  const sessionMap = readSessionMap(sessionId);
-
+function rehydrateString(content: string, sessionMap: Record<string, string>): { content: string; warnings: string[] } {
   // Collect all unique placeholder tokens found in the content
   const foundTokens = new Set<string>();
   let match: RegExpExecArray | null;
@@ -27,7 +13,7 @@ export function rehydrate(request: RehydrateRequest): RehydrateResult {
   }
 
   if (foundTokens.size === 0) {
-    return { content };
+    return { content, warnings: [] };
   }
 
   // Sort by length DESC to prevent shorter placeholders clobbering longer ones
@@ -45,5 +31,36 @@ export function rehydrate(request: RehydrateRequest): RehydrateResult {
     }
   }
 
-  return warnings.length > 0 ? { content: result, warnings } : { content: result };
+  return { content: result, warnings };
+}
+
+/**
+ * Restores original values from placeholders in the given content,
+ * using the session map identified by sessionId.
+ *
+ * - Known placeholders are replaced with their originalValue.
+ * - Unknown placeholders (hallucinated by the LLM) are left as-is and a
+ *   warning is added to the result.
+ *
+ * Placeholders are replaced longest-first to prevent partial replacements
+ * (e.g. Email_10 being corrupted to Email_1<remaining-0>).
+ */
+export function rehydrate(request: RehydrateRequest): RehydrateResult {
+  const { content, sessionId } = request;
+  const sessionMap = readSessionMap(sessionId);
+
+  if (typeof content === 'string') {
+    const { content: result, warnings } = rehydrateString(content, sessionMap);
+    return warnings.length > 0 ? { content: result, warnings } : { content: result };
+  } else {
+    // Array of messages
+    const warnings: string[] = [];
+    const result = content.map((msg) => {
+      const { content: rehydratedStr, warnings: msgWarnings } = rehydrateString(msg.content, sessionMap);
+      warnings.push(...msgWarnings);
+      return { ...msg, content: rehydratedStr };
+    });
+
+    return warnings.length > 0 ? { content: result, warnings } : { content: result };
+  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,11 +42,11 @@ export interface ScrubResult {
 }
 
 export interface RehydrateRequest {
-  content: string;
+  content: string | Message[];
   sessionId: string;
 }
 
 export interface RehydrateResult {
-  content: string;
+  content: string | Message[];
   warnings?: string[]; // Populated if the model invents a placeholder not in the session map
 }

--- a/tests/core/rehydrate.test.ts
+++ b/tests/core/rehydrate.test.ts
@@ -103,3 +103,84 @@ test('same placeholder appearing multiple times is fully replaced', (t) => {
   });
   t.is(result.content, 'bob@example.com said hello to bob@example.com');
 });
+
+test('Message[] input is rehydrated and structure is preserved', (t) => {
+  const sessionId = seedSession('rh-msg-arr', {
+    Email_1: 'alice@example.com',
+    Secret_1: 'sk-secret123',
+  });
+  const messages = [
+    { role: 'system', content: 'You are an assistant. Do not leak Secret_1.' },
+    { role: 'user', content: 'My email is Email_1' },
+    { role: 'assistant', content: 'I will not leak Secret_1.' },
+  ];
+  
+  const result = rehydrate({ content: messages, sessionId });
+  
+  t.true(Array.isArray(result.content));
+  if (Array.isArray(result.content)) {
+    t.is(result.content.length, 3);
+    t.is(result.content[0]!.role, 'system');
+    t.is(result.content[0]!.content, 'You are an assistant. Do not leak sk-secret123.');
+    t.is(result.content[1]!.role, 'user');
+    t.is(result.content[1]!.content, 'My email is alice@example.com');
+    t.is(result.content[2]!.role, 'assistant');
+    t.is(result.content[2]!.content, 'I will not leak sk-secret123.');
+  }
+  t.falsy(result.warnings);
+});
+
+test('Message[] with hallucinated placeholders aggregates warnings', (t) => {
+  const sessionId = seedSession('rh-msg-warn', {
+    Email_1: 'alice@example.com',
+  });
+  const messages = [
+    { role: 'user', content: 'Contact Email_1 or Phone_99' },
+    { role: 'assistant', content: 'I also see Secret_99' },
+  ];
+  
+  const result = rehydrate({ content: messages, sessionId });
+  
+  t.true(Array.isArray(result.content));
+  if (Array.isArray(result.content)) {
+    t.is(result.content[0]!.content, 'Contact alice@example.com or Phone_99');
+    t.is(result.content[1]!.content, 'I also see Secret_99');
+  }
+  
+  t.truthy(result.warnings);
+  t.is(result.warnings?.length, 2);
+  t.regex(result.warnings![0]!, /Phone_99/);
+  t.regex(result.warnings![1]!, /Secret_99/);
+});
+
+import { scrub } from '../../src/core/scrub.js';
+
+test('round-trip: scrub(Message[]) -> rehydrate(Message[]) restores originals', (t) => {
+  const originalMessages = [
+    { role: 'user', content: 'My email is user@example.com' },
+    { role: 'assistant', content: 'I have logged user@example.com into the system.' }
+  ];
+  
+  // 1. Scrub
+  const scrubResult = scrub({ content: originalMessages, sessionId: 'rh-round-trip' });
+  t.true(Array.isArray(scrubResult.scrubbedContent));
+  
+  // 2. Assert scrubbed content has placeholders
+  if (Array.isArray(scrubResult.scrubbedContent)) {
+    t.regex(scrubResult.scrubbedContent[0]!.content, /Email_1/);
+    t.notRegex(scrubResult.scrubbedContent[0]!.content, /user@example.com/);
+  }
+
+  // 3. Rehydrate
+  const rehydrateResult = rehydrate({ 
+    content: scrubResult.scrubbedContent, 
+    sessionId: scrubResult.sessionId 
+  });
+  
+  // 4. Assert structure and content is fully restored
+  t.true(Array.isArray(rehydrateResult.content));
+  if (Array.isArray(rehydrateResult.content)) {
+    t.deepEqual(rehydrateResult.content, originalMessages);
+  }
+  t.falsy(rehydrateResult.warnings);
+});


### PR DESCRIPTION
Closes #35

## Description

This PR extends the `rehydrate()` API to support `Message[]` inputs, bringing it into parity with `scrub()` and eliminating the need for callers to manually unwrap and rewrap message arrays.

### What's included

* Expanded `RehydrateRequest.content` and `RehydrateResult.content` to accept `string | Message[]`.
* Updated the rehydration pipeline to process each message's `content` while preserving the original message structure, including roles and metadata.
* Aggregated warnings across all messages into a single `warnings` array.
* Preserved existing string-based behavior, ensuring full backwards compatibility.
* Maintained API symmetry between `scrub()` and `rehydrate()`.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Refactoring

## Testing Notes

### Automated tests

* Ran `pnpm run test:all`.
* Added tests covering:

  * `Message[]` structure preservation,
  * warning aggregation across multiple messages,
  * end-to-end `scrub(messages) → rehydrate(messages)` round-tripping.
* Verified all **205** tests pass successfully.

### Manual verification

* Verified `rehydrate()` continues to behave identically for `string` inputs.
* Verified `Message[]` inputs retain their original structure while each message's `content` is correctly rehydrated.
* Verified warnings from multiple messages are aggregated into a single result.
* Verified message arrays round-trip correctly through the `scrub()` and `rehydrate()` pipeline.

## Checklist

* [x] I have self-reviewed my code.
* [x] I have formatted, linted, and passed all tests (`pnpm run check` / `pnpm run test:all`).
* [x] I have added/updated tests if necessary.
* [ ] I have added/updated documentation if necessary.
* [x] I have NOT bumped the version in `package.json` (maintainers will handle this).
