### PR TITLE
chore: restrict npm package contents before first publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,14 @@
   "bin": {
     "prompt-scrub": "./dist/cli/index.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
   "publishConfig": {
     "access": "public"
   },
@@ -18,6 +26,7 @@
   },
   "scripts": {
     "build": "rm -rf dist && tsc && chmod +x dist/cli/index.js",
+    "prepublishOnly": "pnpm run build",
     "pretest": "pnpm run test:types",
     "test": "pnpm run test:ava",
     "test:watch": "ava --watch",
@@ -40,7 +49,16 @@
     "type": "git",
     "url": "git+https://github.com/Nano-Collective/prompt-scrubber.git"
   },
-  "keywords": [],
+  "keywords": [
+    "prompt",
+    "privacy",
+    "redaction",
+    "pii",
+    "llm",
+    "scrubber",
+    "ai",
+    "sanitize"
+  ],
   "author": "Nano Collective",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Closes #48

## Description

This PR restricts the published npm package contents to the build output and package metadata, preventing source files, tests, documentation, examples, scripts, and internal tooling from being included in the published tarball.

### What's included

* Added an npm package allowlist so only the compiled build output and required package metadata are included in published releases.
* Added a `prepublishOnly` lifecycle hook to ensure a fresh build is generated before every publish.
* Excluded development-only directories and internal project files from the published package, including:

  * `src/`
  * `tests/`
  * `docs/`
  * `examples/`
  * `scripts/`
  * `.nanocoder/`
* Included optional package metadata improvements (`engines` and `keywords`) to better communicate the supported runtime and improve npm discoverability.

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update
* [x] Refactoring

## Testing Notes

### Automated tests

* Ran `pnpm run test:all`.
* Verified all **205** tests pass successfully.
* Verified the package builds successfully before publishing.

### Manual verification

* Verified `npm pack --dry-run` contains only the compiled build output (`dist/**`) together with `package.json`, `README.md`, and `LICENSE`.
* Verified `src/`, `tests/`, `docs/`, `examples/`, `scripts/`, and `.nanocoder/` are excluded from the published tarball.
* Installed the generated tarball into a clean scratch project and verified:

  * `import { scrub, rehydrate } from '@nanocollective/prompt-scrub'` resolves correctly.
  * The `prompt-scrub` CLI binary is available and functions correctly.
* Verified the `prepublishOnly` lifecycle executes successfully before publishing.

## Checklist

* [x] I have self-reviewed my code.
* [x] I have formatted, linted, and passed all tests (`pnpm run check` / `pnpm run test:all`).
* [ ] I have added/updated documentation if necessary.
* [ ] I have added/updated tests if necessary.
* [x] I have NOT bumped the version in `package.json` (maintainers will handle this).
