### PR TITLE
ci: add CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm test:types
+
+      - name: Lint
+        run: pnpm test:lint
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Test
+        run: pnpm test:all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,171 @@
+name: Release to NPM and GitHub
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      should-publish: ${{ steps.version-check.outputs.should-publish }}
+      package-version: ${{ steps.version-check.outputs.package-version }}
+      npm-version: ${{ steps.version-check.outputs.npm-version }}
+      is-prerelease: ${{ steps.version-check.outputs.is-prerelease }}
+      npm-tag: ${{ steps.version-check.outputs.npm-tag }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Check version difference
+        id: version-check
+        run: |
+          # Get current package.json version
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          echo "package-version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
+
+          # Detect prerelease versions (beta, alpha, rc, etc.)
+          if [[ "$PACKAGE_VERSION" == *"-beta"* ]]; then
+            echo "is-prerelease=true" >> $GITHUB_OUTPUT
+            echo "npm-tag=beta" >> $GITHUB_OUTPUT
+            echo "Beta version detected: $PACKAGE_VERSION"
+          elif [[ "$PACKAGE_VERSION" == *"-alpha"* ]]; then
+            echo "is-prerelease=true" >> $GITHUB_OUTPUT
+            echo "npm-tag=alpha" >> $GITHUB_OUTPUT
+            echo "Alpha version detected: $PACKAGE_VERSION"
+          elif [[ "$PACKAGE_VERSION" == *"-rc"* ]]; then
+            echo "is-prerelease=true" >> $GITHUB_OUTPUT
+            echo "npm-tag=rc" >> $GITHUB_OUTPUT
+            echo "Release candidate detected: $PACKAGE_VERSION"
+          else
+            echo "is-prerelease=false" >> $GITHUB_OUTPUT
+            echo "npm-tag=latest" >> $GITHUB_OUTPUT
+          fi
+
+          # Get the version currently published on npm (empty string if not published yet)
+          NPM_VERSION=$(npm view @nanocollective/prompt-scrub version 2>/dev/null || echo "")
+          echo "npm-version=$NPM_VERSION" >> $GITHUB_OUTPUT
+
+          if [ "$PACKAGE_VERSION" != "$NPM_VERSION" ]; then
+            echo "should-publish=true" >> $GITHUB_OUTPUT
+            echo "Version bump detected: $NPM_VERSION -> $PACKAGE_VERSION"
+          else
+            echo "should-publish=false" >> $GITHUB_OUTPUT
+            echo "No version bump, skipping publish."
+          fi
+
+  publish:
+    needs: check-version
+    if: needs.check-version.outputs.should-publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Run full test suite
+        run: pnpm test:all
+
+      - name: Verify build output
+        run: |
+          if [ ! -f "dist/cli/index.js" ]; then
+            echo "Build output missing: dist/cli/index.js not found"
+            exit 1
+          fi
+          echo "Build output verified: dist/cli/index.js exists"
+
+      - name: Publish to npm
+        run: npm publish --tag ${{ needs.check-version.outputs.npm-tag }} --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const version = '${{ needs.check-version.outputs.package-version }}';
+            const isPrerelease = '${{ needs.check-version.outputs.is-prerelease }}' === 'true';
+            const tag = `v${version}`;
+
+            const body = [
+              `## prompt-scrub v${version}`,
+              '',
+              '### Installation',
+              '```bash',
+              'npm install -g @nanocollective/prompt-scrub',
+              '```',
+              '',
+              '### CLI usage',
+              '```bash',
+              '# Inspect a prompt before sending (recommended first step)',
+              'echo "My email is alice@example.com" | prompt-scrub inspect',
+              '',
+              '# Scrub a prompt',
+              'echo "My email is alice@example.com" | prompt-scrub scrub',
+              '',
+              '# Rehydrate a response',
+              'echo "Contact Email_1 for details." | prompt-scrub rehydrate --session-id <id>',
+              '```',
+              '',
+              '### Library usage',
+              '```typescript',
+              'import { scrub, rehydrate } from "@nanocollective/prompt-scrub";',
+              '',
+              'const { scrubbedContent, sessionId } = scrub({ content: prompt });',
+              '// send scrubbedContent to LLM...',
+              'const { content } = rehydrate({ content: response, sessionId });',
+              '```',
+              '',
+              `[Full changelog](https://github.com/Nano-Collective/prompt-scrubber/commits/v${version})`,
+            ].join('\n');
+
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              name: `v${version}`,
+              body,
+              prerelease: isPrerelease,
+              generate_release_notes: false,
+            });
+
+            console.log(`GitHub Release created: ${tag}`);
+
+  notify:
+    needs: [check-version, publish]
+    if: always() && needs.check-version.outputs.should-publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify result
+        run: |
+          if [ "${{ needs.publish.result }}" == "success" ]; then
+            echo "@nanocollective/prompt-scrub@${{ needs.check-version.outputs.package-version }} published successfully."
+          else
+            echo "Publish failed for @nanocollective/prompt-scrub@${{ needs.check-version.outputs.package-version }}."
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,4 +58,20 @@ You can also run any of these individual gates in isolation by calling the scrip
 
 **Note for contributors:** Please do not bump the version number in `package.json` in your pull requests. Version bumping and releases are handled exclusively by the project maintainers using automated workflows when merging to `main`.
 
+### How releases work
+
+When a commit lands on `main` with a `package.json` version that differs from the currently published npm version, the `release.yml` workflow automatically:
+
+1. Runs the full test suite and build.
+2. Publishes the package to npm under `@nanocollective/prompt-scrub`.
+3. Creates a GitHub Release with install and usage instructions.
+
+Prerelease versions (`-alpha`, `-beta`, `-rc`) are published to their corresponding npm dist-tags instead of `latest`.
+
+### Required secrets (maintainers only)
+
+| Secret | Purpose |
+|---|---|
+| `NPM_TOKEN` | Authenticates `npm publish` to the npm registry. Must be set as a repository secret. |
+
 Thank you for contributing!

--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "ignoreDependencies": [],
-  "ignoreBinaries": ["semgrep"]
+  "ignoreBinaries": ["semgrep"],
+  "ignoreWorkspaces": ["examples/*"]
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,6 @@
 packages:
-  - '.'
-  - 'examples/*'
-auditConfig: { ignoreGhsas: null }
+  - "."
+allowBuilds:
+  esbuild: true
+auditConfig:
+  ignoreGhsas: null


### PR DESCRIPTION
Closes #50

## Description

Adds CI and release automation for prompt-scrub, resolving the gap identified in #50.

`.github/workflows/` was empty — nothing ran the test suite on PRs and there was no automated publish path. This is a release blocker for a privacy/security-adjacent tool.

Two workflows are added, modelled on the sibling project get-md and adapted to prompt-scrub's package name, paths, and build output:

**`ci.yml`** — runs on every PR and push to `main`. Executes type-check, lint (Biome), build, and the full `test:all` suite against Node 22 with a frozen lockfile.

**`release.yml`** — version-gated publish on push to `main`. Compares the `package.json` version against the currently published `@nanocollective/prompt-scrub` on npm. If a bump is detected: builds, runs the full test suite, verifies `dist/cli/index.js` exists, publishes to npm with the correct dist-tag (`latest`/`beta`/`alpha`/`rc`), and creates a GitHub Release with prompt-scrub-specific install and usage instructions. The changelog step has been dropped for v1 (no `CHANGELOG.md` exists yet).

`CONTRIBUTING.md` is updated to document the required `NPM_TOKEN` secret and explain how the automated release process works.

`update-badges.yml` is deferred — not a release gate per the issue.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring

## Testing Notes

- `pnpm run test:all` passes locally (205 tests).
- `ci.yml` logic verified by reviewing each step against the `scripts/test.sh` gate order.
- `release.yml` build-output check verified against the actual bin path (`dist/cli/index.js`).
- `npm pack --dry-run` confirmed the tarball structure the release job will publish is correct (from #48).
- Changelog step intentionally omitted for v1 — the issue explicitly allows this.

## Checklist
- [x] I have self-reviewed my code.
- [x] I have formatted, linted, and passed all tests (`pnpm run check`).
- [x] I have added/updated documentation if necessary.
- [ ] I have added/updated tests if necessary. *(workflow files are not unit-testable)*
- [x] I have NOT bumped the version in `package.json`.