### PR TITLE
fix: clarify stateless session map contract

### DIFF
--- a/docs/features/session-management.md
+++ b/docs/features/session-management.md
@@ -20,6 +20,15 @@ A session map is a simple key-value dictionary where the key is the placeholder 
 }
 ```
 
+## Storage Modes
+
+The Node.js API chooses storage from the presence of `sessionMap`:
+
+- **Disk-backed:** omit `sessionMap`. A provided `sessionId` is loaded from and saved to disk; without one, `scrub()` generates a new ID.
+- **Stateless:** pass a map, including `{}`. The caller owns the map, it is mutated in place and returned, and no session file is read or written. A `sessionId` may still be supplied as metadata, but it does not enable persistence.
+
+Passing `sessionMap: undefined` is equivalent to omitting it, so it selects disk-backed storage and emits a runtime warning. Pass `{}` when stateless execution is required, especially in serverless or read-only environments.
+
 ## Storage Location
 
 Sessions are stored as JSON files on disk in the user's config directory:

--- a/docs/getting-started/api.md
+++ b/docs/getting-started/api.md
@@ -6,7 +6,7 @@ sidebar_order: 1
 
 # v1 API Reference
 
-The primary interface for `prompt-scrub` is designed to be simple and stateless from the caller's perspective, delegating session persistence to the library.
+The primary interface for `prompt-scrub` supports both disk-backed sessions and caller-owned stateless sessions.
 
 ## Core Functions
 
@@ -25,6 +25,32 @@ const result = scrub({
 // result.scrubbedContent contains the text with placeholders
 // result.sessionId contains the session ID used
 ```
+
+#### Choosing a storage mode
+
+Omit `sessionMap` to use disk-backed storage. When `sessionId` is provided, that session is loaded from and saved to the filesystem; otherwise a new ID is generated.
+
+```typescript
+const result = scrub({
+  content: prompt,
+  sessionId: "abc123"
+});
+```
+
+Provide a map — including an empty object — to use stateless mode. The same object is updated and returned, and no session file is read or written.
+
+```typescript
+const sessionMap = {};
+const result = scrub({
+  content: prompt,
+  sessionId: "abc123", // Optional metadata in stateless mode
+  sessionMap
+});
+
+console.log(result.sessionMap === sessionMap); // true
+```
+
+`sessionMap: undefined` is not stateless mode: at runtime it is treated like an omitted property, selects disk-backed storage, and emits a warning. TypeScript projects with `exactOptionalPropertyTypes` enabled reject that explicit assignment; other TypeScript and JavaScript callers receive the runtime warning. Omit the property for disk mode or pass `{}` for stateless mode.
 
 ### `rehydrate`
 
@@ -58,7 +84,12 @@ export interface Message {
 export interface ScrubRequest {
   content: string | Message[];
   sessionId?: string;
+  sessionMap?: SessionMap;
   options?: ScrubOptions;
+}
+
+export interface SessionMap {
+  [placeholder: string]: string;
 }
 
 export interface ScrubOptions {
@@ -68,16 +99,18 @@ export interface ScrubOptions {
 
 export interface ScrubResult {
   scrubbedContent: string | Message[];
-  sessionId: string;
+  sessionId?: string;
+  sessionMap?: SessionMap;
 }
 
 export interface RehydrateRequest {
-  content: string;
-  sessionId: string;
+  content: string | Message[];
+  sessionId?: string;
+  sessionMap?: SessionMap;
 }
 
 export interface RehydrateResult {
-  content: string;
+  content: string | Message[];
   warnings?: string[]; // Populated if the model invents a placeholder not in the session map
 }
 ```

--- a/src/core/scrub.ts
+++ b/src/core/scrub.ts
@@ -19,6 +19,9 @@ const DEFAULT_DETECTORS: Detector[] = [
   new PostalAddressDetector(),
 ];
 
+const EXPLICIT_UNDEFINED_SESSION_MAP_WARNING =
+  'sessionMap was explicitly set to undefined; scrub() will use disk-backed session storage. Omit sessionMap for disk mode or pass {} for stateless mode.';
+
 /**
  * Scrubs a single string, returning the scrubbed text.
  * All replacements are recorded in the provided SessionManager.
@@ -101,6 +104,10 @@ export function getActiveDetectors(options?: ScrubRequest['options']): Detector[
  */
 export function scrub(request: ScrubRequest): ScrubResult {
   const { content, sessionId, sessionMap, options } = request;
+
+  if (Object.hasOwn(request, 'sessionMap') && sessionMap === undefined) {
+    console.warn(EXPLICIT_UNDEFINED_SESSION_MAP_WARNING);
+  }
 
   const session = new SessionManager(sessionId, sessionMap);
   const detectors = getActiveDetectors(options);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,7 +24,12 @@ export interface Message {
 export interface ScrubRequest {
   content: string | Message[];
   sessionId?: string;
-  sessionMap?: Record<string, string>;
+  /**
+   * Providing a map, including an empty object, enables stateless mode and
+   * prevents disk I/O. Omit this property for disk-backed sessions. Explicit
+   * `undefined` is treated as omission at runtime and emits a warning.
+   */
+  sessionMap?: SessionMap;
   options?: ScrubOptions;
 }
 
@@ -40,7 +45,7 @@ export interface ScrubOptions {
 export interface ScrubResult {
   scrubbedContent: string | Message[];
   sessionId?: string;
-  sessionMap?: Record<string, string>;
+  sessionMap?: SessionMap;
 }
 
 export interface RehydrateRequest {

--- a/tests/core/scrub.test.ts
+++ b/tests/core/scrub.test.ts
@@ -125,6 +125,48 @@ test('no disk write when nothing is scrubbed', (t) => {
   t.is(sessionsBefore, sessionsAfter);
 });
 
+test.serial('explicit undefined sessionMap warns before using disk storage', (t) => {
+  const sessionId = 'explicit-undefined-contract';
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(' '));
+
+  try {
+    scrub({
+      content: 'My email is omitted@example.com',
+      sessionId: 'omitted-map-contract',
+    });
+    t.deepEqual(warnings, []);
+
+    scrub({
+      content: 'My email is explicit@example.com',
+      sessionId,
+      sessionMap: undefined,
+    } as unknown as Parameters<typeof scrub>[0]);
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  t.deepEqual(warnings, [
+    'sessionMap was explicitly set to undefined; scrub() will use disk-backed session storage. Omit sessionMap for disk mode or pass {} for stateless mode.',
+  ]);
+  t.true(fs.existsSync(path.join(tmpConfigDir, 'sessions', `${sessionId}.json`)));
+});
+
+test('an empty sessionMap uses stateless mode without writing to disk', (t) => {
+  const sessionId = 'empty-map-stateless';
+  const sessionMap: Record<string, string> = {};
+  const result = scrub({
+    content: 'My email is stateless@example.com',
+    sessionId,
+    sessionMap,
+  });
+
+  t.is(result.sessionMap, sessionMap);
+  t.deepEqual(sessionMap, { '«Email_1»': 'stateless@example.com' });
+  t.false(fs.existsSync(path.join(tmpConfigDir, 'sessions', `${sessionId}.json`)));
+});
+
 // --- Message[] Input ---
 
 test('Message[] input: scrubs each message independently and preserves structure', (t) => {


### PR DESCRIPTION
## Description

Clarifies and enforces the `sessionMap` storage contract for `scrub()`:

- omitting `sessionMap` keeps the normal disk-backed behavior without a warning
- explicitly passing `sessionMap: undefined` still uses disk storage, but now warns instead of failing silently
- passing a map, including `{}`, remains stateless, mutates the caller-owned map in place, and performs no session-file I/O
- the public type comments and API/session documentation now describe those modes and the TypeScript `exactOptionalPropertyTypes` distinction

Fixes #87.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Testing Notes

The new regression test was run before the fix: the explicit-`undefined` warning assertion failed while the other 19 `scrub.test.ts` cases, including the empty-map stateless case, passed.

After the fix:

- `pnpm exec ava tests/core/scrub.test.ts`: 20 passed
- `pnpm run test:all`: 207 AVA tests passed; format, types, lint, knip, and dependency audit passed
- Semgrep was skipped by the repository script because it is not installed in PATH
- Biome emitted one existing informational notice that `biome.json` references schema 2.5.3 while the installed CLI is 2.5.7
- `git diff --check`: passed

## Checklist
- [x] I have self-reviewed my code.
- [x] I have formatted, linted, and passed all tests (`pnpm run check`).
- [x] I have added/updated documentation if necessary.
- [x] I have added/updated tests if necessary.
- [x] I have NOT bumped the version in `package.json` (maintainers will handle this).
