### PR TITLE
chore: add issue assignment checkbox to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@ Please describe how you tested this change.
 - Manual verification steps?
 
 ## Checklist
+- [ ] If this was for an open issue, I was assigned to it
 - [ ] I have self-reviewed my code.
 - [ ] I have formatted, linted, and passed all tests (`pnpm run check`).
 - [ ] I have added/updated documentation if necessary.


### PR DESCRIPTION
## Description

This PR updates the `.github/PULL_REQUEST_TEMPLATE.md` to include a new checkbox under the Checklist section:
`- [ ] If this was for an open issue, I was assigned to it`

This aims to gently enforce the contribution process by ensuring contributors request assignment on issues before opening PRs.
An empty changeset was also added as this is an internal chore/docs update.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring

## Testing Notes

- Verified that the checkbox is correctly formatted in the markdown template.
- No automated tests required for this internal documentation chore.

## Checklist

- [x] I have self-reviewed my code.
- [x] I have formatted, linted, and passed all tests (`pnpm run check`).
- [x] I have added/updated documentation if necessary.
- [x] I have added/updated tests if necessary.
- [x] I have NOT bumped the version in `package.json` (maintainers will handle this).