### PR TITLE
fix: detect common names in strict mode

### DIFF
--- a/src/detectors/name.ts
+++ b/src/detectors/name.ts
@@ -4,18 +4,9 @@ import type { Detector, Finding } from '../types/index.js';
 // e.g., "Alice", "John Doe", "San Francisco"
 const NAME_REGEX = /\b[A-Z][a-z]+(?: [A-Z][a-z]+)*\b/g;
 
-// A small built-in allowlist for strict mode covering common first names, countries,
-// languages, and widely recognized product names.
+// A small built-in allowlist for strict mode covering countries, languages,
+// and widely recognized product names.
 const ALLOWLIST = new Set([
-  // Common first names
-  'john',
-  'jane',
-  'michael',
-  'sarah',
-  'david',
-  'emily',
-  'james',
-  'jessica',
   // Countries
   'united states',
   'canada',

--- a/tests/cli/scrub.test.ts
+++ b/tests/cli/scrub.test.ts
@@ -54,8 +54,7 @@ test('handleScrub respects strictName option', async (t) => {
     enable: 'NameDetector',
     strictName: true,
   });
-  // 'John' is in the allowlist, so it should not be scrubbed in strict mode
-  t.is(result.scrubbedContent, 'Hello John.');
+  t.is(result.scrubbedContent, 'Hello «Name_1».');
 });
 
 test('handleScrub respects codeTellTerms', async (t) => {

--- a/tests/core/scrub.test.ts
+++ b/tests/core/scrub.test.ts
@@ -192,7 +192,7 @@ test('NameDetector works when explicitly enabled', (t) => {
 });
 
 test('NameDetector works in strict mode', (t) => {
-  // 'John' and 'London' (not in allowlist) vs allowlisted 'France'
+  // Names are detected while allowlisted countries are left unchanged.
   const text = 'John visited France and London.';
   const scrubbed = scrub({
     content: text,
@@ -202,9 +202,7 @@ test('NameDetector works in strict mode', (t) => {
     },
   });
 
-  // France is allowlisted, John is allowlisted (wait, 'John' is in allowlist!).
-  // London is not allowlisted.
-  t.is(scrubbed.scrubbedContent, 'John visited France and «Name_1».');
+  t.is(scrubbed.scrubbedContent, '«Name_1» visited France and «Name_2».');
 });
 
 test('NameDetector round-trips correctly', (t) => {

--- a/tests/detectors/name.test.ts
+++ b/tests/detectors/name.test.ts
@@ -35,9 +35,10 @@ test('detects multiple names', (t) => {
 
 // --- Strict Mode Cases ---
 
-test('strict mode skips allowlisted first names', (t) => {
-  const findings = strictDetector.detect('John went to the store with Jane.');
-  t.is(findings.length, 0); // John and Jane are allowlisted
+test('strict mode detects common first names', (t) => {
+  const findings = strictDetector.detect('John Doe works at Google.');
+  t.is(findings.length, 1);
+  t.is(findings[0]?.value, 'John Doe');
 });
 
 test('strict mode skips allowlisted countries and languages', (t) => {


### PR DESCRIPTION
## Description

Strict mode currently allowlists common first names, which lets likely PII such as John Doe pass through. This removes those names from the allowlist while preserving countries, languages, products, days, and months.

Fixes #84

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing Notes

- Targeted Biome formatting and lint checks passed.
- TypeScript typecheck passed.
- Detector, core, and CLI regression coverage was updated.
- The AVA worker cannot start in this Windows sandbox because Node returns `uv_os_get_passwd ENOMEM`; repository CI will run the full suite.

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [x] I have self-reviewed my code.
- [ ] I have formatted, linted, and passed all tests (`pnpm run check`).
- [x] I have added/updated documentation if necessary.
- [x] I have added/updated tests if necessary.
- [x] I have NOT bumped the version in `package.json` (maintainers will handle this).