### PR TITLE
fix: avoid address matches across long prose

### DIFF
--- a/src/detectors/postal-address.ts
+++ b/src/detectors/postal-address.ts
@@ -1,9 +1,9 @@
 import type { Detector, Finding } from '../types/index.js';
 
-// Conservative matching only: number + word(s) + street suffix.
+// Conservative matching only: number + up to five street-name words + street suffix.
 // Examples: 123 Main Street, 45 Oak Road, 1600 Pennsylvania Ave., 10 Downing St, 221B Baker St.
 const ADDRESS_REGEX =
-  /\b\d{1,6}[A-Za-z]?\s+[A-Za-z0-9\s.,'-]+?\b(?:street|st|road|rd|avenue|ave|boulevard|blvd|lane|ln|drive|dr|court|ct|place|pl|square|sq|terrace|ter)\b\.?/gi;
+  /\b\d{1,6}[A-Za-z]?\s+(?:[A-Za-z0-9][A-Za-z0-9.,'-]*\s+){1,5}(?:street|st|road|rd|avenue|ave|boulevard|blvd|lane|ln|drive|dr|court|ct|place|pl|square|sq|terrace|ter)\b\.?/gi;
 
 export class PostalAddressDetector implements Detector {
   readonly name = 'AddressDetector';

--- a/tests/detectors/postal-address.test.ts
+++ b/tests/detectors/postal-address.test.ts
@@ -58,3 +58,10 @@ test('does not fire on plain text', (t) => {
   const findings = detector.detect('I live down the street from here.');
   t.is(findings.length, 0);
 });
+
+test('does not treat long prose ending in a street suffix as an address', (t) => {
+  const findings = detector.detect(
+    'There are 42 things you should consider when walking down the st.',
+  );
+  t.is(findings.length, 0);
+});


### PR DESCRIPTION
## Description

The postal-address regex can span unlimited prose before a street suffix, so a sentence ending in "st." may be treated as an address. This bounds the street-name segment to one through five words while preserving normal addresses.

Fixes #86

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing Notes

- Targeted Biome formatting and lint checks passed.
- TypeScript typecheck passed.
- A compiled regression probe passed for both the prose false positive and valid address cases.
- The AVA worker cannot start in this Windows sandbox because Node returns `uv_os_get_passwd ENOMEM`; repository CI will run the full suite.

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [x] I have self-reviewed my code.
- [ ] I have formatted, linted, and passed all tests (`pnpm run check`).
- [x] I have added/updated documentation if necessary.
- [x] I have added/updated tests if necessary.
- [x] I have NOT bumped the version in `package.json` (maintainers will handle this).