### PR TITLE
fix(phone): derive span start index from match[0] and value length di…

### DIFF
--- a/src/detectors/phone.ts
+++ b/src/detectors/phone.ts
@@ -26,9 +26,11 @@ export class PhoneDetector implements Detector {
         const digits = value.replace(/\D/g, '');
         if (digits.length < 7) continue;
 
+        const start = match.index + (match[0].length - value.length);
+
         raw.push({
           category: 'Phone',
-          span: [match.index, match.index + value.length],
+          span: [start, start + value.length],
           value,
           placeholderPrefix: 'Phone',
         });

--- a/tests/detectors/phone.test.ts
+++ b/tests/detectors/phone.test.ts
@@ -86,3 +86,13 @@ test('resolves overlapping matches by picking the longer one', (t) => {
   t.is(findings[0]?.value, '+1-23-4-567');
   t.is(findings[1]?.value, '567-890-1234');
 });
+
+test('span accurately reflects value slice in text', (t) => {
+  const text = 'Call me at +1-555-123-4567 or (555) 123-4567 anytime.';
+  const findings = detector.detect(text);
+  for (const finding of findings) {
+    const [start, end] = finding.span;
+    t.is(text.slice(start, end), finding.value);
+  }
+});
+


### PR DESCRIPTION
## Description
In `PhoneDetector`, when regex patterns use capture groups (`match[1]`), using `match.index` directly assumes the capture group starts at index 0 of `match[0]`. If regex patterns ever include a non-zero-width prefix before the capture group, `match.index` would produce misaligned spans. This PR updates the span start calculation to `match.index + (match[0].length - value.length)`, making it robust and consistent with other detectors in the codebase (e.g. `PathDetector`, `URLDetector`, `SecretDetector`).

Fixes #85

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing Notes
- **Automated tests run**:
  - `npx ava tests/detectors/phone.test.ts` (14/14 tests passing)
  - `npx ava tests/detectors/*.test.ts` (95/95 tests passing)
- **Verification**:
  - Added unit test `span accurately reflects value slice in text` to ensure `text.slice(start, end)` strictly equals `finding.value`.

## Checklist
- [x] If this was for an open issue, I was assigned to it
- [x] I have self-reviewed my code.
- [x] I have formatted, linted, and passed all tests (`pnpm run check`).
- [ ] I have added/updated documentation if necessary.
- [x] I have added/updated tests if necessary.
- [x] I have NOT bumped the version in `package.json` (maintainers will handle this).
