### PR TITLE
Feature: watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
   - `prompt-scrub watch --clipboard` — monitors clipboard, scrubs data, sends notifications
   - `prompt-scrub watch --file <files...>` — monitors and scrubs files in place
   - Cross-platform: Windows/macOS/Linux
-  - Options: `--interval`, `--once`, `--session-id`, `--disable`, `--enable`, `--url-allowlist`
+  - `--dry-run` previews changes without writing; `--backup` keeps a `<file>.bak` before overwriting
+  - `Ctrl-C` (SIGINT/SIGTERM) clears the poll timer and exits cleanly
+  - Missing platform helpers (`xclip`, `notify-send`, `osascript`) are reported with an install hint instead of failing silently
+  - Options: `--interval`, `--once`, `--dry-run`, `--backup`, `--session-id`, `--disable`, `--enable`, `--url-allowlist`
+  - Documented in `docs/getting-started/cli.md`
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# Unreleased
+
+## Added
+
+- **Watch mode** — `watch` command for real-time clipboard/file monitoring with automatic scrubbing
+  - `prompt-scrub watch --clipboard` — monitors clipboard, scrubs data, sends notifications
+  - `prompt-scrub watch --file <files...>` — monitors and scrubs files in place
+  - Cross-platform: Windows/macOS/Linux
+  - Options: `--interval`, `--once`, `--session-id`, `--disable`, `--enable`, `--url-allowlist`
+
+## Fixed
+
+- **TypeScript compatibility** — Fixed type handling for `ScrubResult.scrubbedContent`
+- **Windows build** — Cross-platform build script
+
 # 1.0.2
 
 Patch release — dev-dependency and CI maintenance only. No public-API or runtime changes.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Or install as a dependency in your Node.js project:
 npm install @nanocollective/prompt-scrub
 ```
 
+### Optional: Initialize Configuration
+
+Create a global configuration file for rule packs and URL allowlists:
+
+```bash
+prompt-scrub config init
+```
+
+See the [CLI Reference](docs/getting-started/cli.md#configuration-management) for details on managing your configuration.
+
 ### Recommended: Inspect first
 
 Before scrubbing, run `inspect` on a real prompt to review what the tool detected before sending your prompt:
@@ -76,6 +86,15 @@ The hash is deterministic — the same prompt always produces the same hash, so 
 ```bash
 echo "My email is user@example.com" | prompt-scrub scrub
 # Output: My email is Email_1
+```
+
+**CLI: Watch clipboard**
+```bash
+# Monitor clipboard and automatically scrub sensitive data
+prompt-scrub watch --clipboard
+
+# Watch a file
+prompt-scrub watch --file prompt.txt --once
 ```
 
 **Node.js API: Scrubbing and Rehydrating**

--- a/README.md
+++ b/README.md
@@ -49,16 +49,6 @@ Or install as a dependency in your Node.js project:
 npm install @nanocollective/prompt-scrub
 ```
 
-### Optional: Initialize Configuration
-
-Create a global configuration file for rule packs and URL allowlists:
-
-```bash
-prompt-scrub config init
-```
-
-See the [CLI Reference](docs/getting-started/cli.md#configuration-management) for details on managing your configuration.
-
 ### Recommended: Inspect first
 
 Before scrubbing, run `inspect` on a real prompt to review what the tool detected before sending your prompt:
@@ -95,7 +85,12 @@ prompt-scrub watch --clipboard
 
 # Watch a file
 prompt-scrub watch --file prompt.txt --once
+
+# Preview changes without writing anything
+prompt-scrub watch --file prompt.txt --dry-run --once
 ```
+
+See the [CLI Reference](docs/getting-started/cli.md#watch-mode) for all watch options and platform requirements.
 
 **Node.js API: Scrubbing and Rehydrating**
 ```typescript

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -33,6 +33,50 @@ Reads a message from `stdin` or a file and prints a human-readable diff of the t
 - `--disable <detectors>`: Comma-separated list of detectors to disable.
 - `--hash`: Print *only* the SHA-256 hash for scripting purposes.
 
+## Watch Mode
+
+### `prompt-scrub watch`
+Continuously monitors your system clipboard and/or one or more files, scrubbing sensitive content in place as soon as it appears. This is aimed at the copy-paste workflow: copy a prompt containing real data, and it is scrubbed before you paste it into a web-based LLM.
+
+At least one of `--clipboard` or `--file` is required. A desktop notification is emitted for each scrub, summarising what was replaced.
+
+```bash
+# Scrub the clipboard continuously
+prompt-scrub watch --clipboard
+
+# Scrub two files, checking twice a second
+prompt-scrub watch --file prompt.txt notes.md --interval 500
+
+# See what would change without writing anything
+prompt-scrub watch --file prompt.txt --dry-run --once
+```
+
+Press `Ctrl-C` to stop watching; the poll loop is cleared and the process exits cleanly.
+
+**Options:**
+- `-c, --clipboard`: Monitor the system clipboard.
+- `-f, --file <files...>`: One or more files to monitor and rewrite in place.
+- `-i, --interval <ms>`: Polling interval in milliseconds (default `1000`).
+- `--once`: Run a single check pass and exit. Useful in scripts and CI.
+- `--dry-run`: Report what would be scrubbed without writing the clipboard or any file.
+- `--backup`: Write `<file>.bak` containing the pre-scrub content before overwriting a watched file.
+- `--session-id <id>`: Reuse an existing session map so placeholders stay stable across runs.
+- `--disable <detectors>`: Comma-separated list of detectors to skip.
+- `--enable <detectors>`: Comma-separated list of off-by-default detectors to enable.
+- `--strict-name`: Enable strict allowlisting for `NameDetector`.
+- `--code-tell-terms <terms>`: Comma-separated list of private identifiers to detect.
+- `--url-allowlist <hosts>`: Comma-separated list of hostnames to pass through.
+
+**Platform requirements:**
+
+Watch mode shells out to a small platform helper for clipboard access and notifications. If the required binary is missing, clipboard monitoring fails immediately with an actionable error, and notifications degrade to a single warning on `stderr` rather than failing silently.
+
+| Platform | Clipboard | Notifications |
+| --- | --- | --- |
+| Windows | `powershell.exe` | `powershell.exe` |
+| macOS | `pbpaste` / `pbcopy` | `osascript` |
+| Linux | `xclip` | `notify-send` (`libnotify-bin`) |
+
 ## Session Management
 
 ### `prompt-scrub sessions list`

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "ignoreDependencies": [],
-  "ignoreBinaries": ["semgrep"],
+  "ignoreBinaries": ["semgrep", "pbcopy", "pbpaste", "xclip", "osascript", "notify-send"],
   "ignoreWorkspaces": ["examples/*"]
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc && chmod +x dist/cli/index.js",
+    "build": "node -e \"require('fs').rmSync('dist', {recursive: true, force: true})\" && tsc",
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run build",
     "pretest": "pnpm run test:types",

--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -1,65 +1,157 @@
-import { execSync } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import type { Command } from 'commander';
 import { handleScrub } from './scrub.js';
 
-export function readClipboard(): string {
-  try {
-    if (process.platform === 'win32') {
-      return execSync('powershell.exe -NoProfile -Command Get-Clipboard', {
-        encoding: 'utf8',
-        stdio: ['pipe', 'pipe', 'ignore'],
-      }).replace(/\r\n$/, '');
-    }
-    if (process.platform === 'darwin') {
-      return execSync('pbpaste', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] });
-    }
-    return execSync('xclip -selection clipboard -o', {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'ignore'],
-    });
-  } catch {
-    return '';
+/**
+ * Every external process below is invoked through `spawnSync` with an argv
+ * array and no shell. Titles, messages and file paths are therefore passed as
+ * opaque arguments and are never parsed by `sh`/`cmd`, so a path such as
+ * `$(whoami).txt` or `it's.txt` cannot break out of the command.
+ */
+
+const commandCache = new Map<string, boolean>();
+
+/** Probe `PATH` once per binary so a missing tool is reported, not swallowed. */
+export function isCommandAvailable(cmd: string): boolean {
+  const cached = commandCache.get(cmd);
+  if (cached !== undefined) return cached;
+
+  const probe = process.platform === 'win32' ? 'where.exe' : 'which';
+  const res = spawnSync(probe, [cmd], { stdio: 'ignore', windowsHide: true });
+  const ok = !res.error && res.status === 0;
+
+  commandCache.set(cmd, ok);
+  return ok;
+}
+
+/** The binary this platform needs for clipboard access. */
+export function clipboardTool(): string {
+  if (process.platform === 'win32') return 'powershell.exe';
+  if (process.platform === 'darwin') return 'pbpaste';
+  return 'xclip';
+}
+
+/** The binary this platform needs for desktop notifications. */
+export function notificationTool(): string {
+  if (process.platform === 'win32') return 'powershell.exe';
+  if (process.platform === 'darwin') return 'osascript';
+  return 'notify-send';
+}
+
+function installHint(tool: string): string {
+  switch (tool) {
+    case 'xclip':
+      return 'Install it with `sudo apt install xclip` (or your distro equivalent).';
+    case 'notify-send':
+      return 'Install it with `sudo apt install libnotify-bin` (or your distro equivalent).';
+    case 'pbpaste':
+    case 'osascript':
+      return 'It ships with macOS - check that /usr/bin is on your PATH.';
+    default:
+      return 'Check that it is installed and on your PATH.';
   }
 }
 
-export function writeClipboard(content: string): void {
-  try {
-    if (process.platform === 'win32') {
-      execSync(
-        'powershell.exe -NoProfile -Command "Set-Clipboard -Value ([Environment]::GetEnvironmentVariable(\'CLIP_TEXT\'))"',
-        {
-          env: { ...process.env, CLIP_TEXT: content },
-          stdio: ['pipe', 'pipe', 'ignore'],
-        },
-      );
-      return;
-    }
-    if (process.platform === 'darwin') {
-      execSync('pbcopy', { input: content, stdio: ['pipe', 'pipe', 'ignore'] });
-      return;
-    }
-    execSync('xclip -selection clipboard', { input: content, stdio: ['pipe', 'pipe', 'ignore'] });
-  } catch {}
+/** Fail fast with an actionable message rather than silently reading '' forever. */
+export function assertClipboardSupport(): void {
+  const tool = clipboardTool();
+  if (!isCommandAvailable(tool)) {
+    throw new Error(
+      `Clipboard monitoring requires \`${tool}\`, which was not found on your PATH. ${installHint(tool)}`,
+    );
+  }
 }
 
-export function sendNotification(title: string, message: string): void {
-  try {
-    if (process.platform === 'darwin') {
-      execSync(`osascript -e 'display notification "${message}" with title "${title}"'`, {
-        stdio: ['pipe', 'pipe', 'ignore'],
-      });
-    } else if (process.platform === 'win32') {
-      const psCmd = `[reflection.assembly]::loadwithpartialname('System.Windows.Forms'); $notify = new-object system.windows.forms.notifyicon; $notify.icon = [system.drawing.systemicons]::information; $notify.visible = $true; $notify.showballoontip(3000, '${title}', '${message}', [system.windows.forms.tooltipicon]::info)`;
-      execSync(`powershell.exe -NoProfile -Command "${psCmd}"`, {
-        stdio: ['pipe', 'pipe', 'ignore'],
-      });
-    } else if (process.platform === 'linux') {
-      execSync(`notify-send "${title}" "${message}"`, {
-        stdio: ['pipe', 'pipe', 'ignore'],
-      });
+function readClipboard(): string {
+  let res: ReturnType<typeof spawnSync>;
+  if (process.platform === 'win32') {
+    res = spawnSync('powershell.exe', ['-NoProfile', '-Command', 'Get-Clipboard'], {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+  } else if (process.platform === 'darwin') {
+    res = spawnSync('pbpaste', [], { encoding: 'utf8' });
+  } else {
+    res = spawnSync('xclip', ['-selection', 'clipboard', '-o'], { encoding: 'utf8' });
+  }
+
+  if (res.error || res.status !== 0 || typeof res.stdout !== 'string') return '';
+  return process.platform === 'win32' ? res.stdout.replace(/\r\n$/, '') : res.stdout;
+}
+
+function writeClipboard(content: string): void {
+  if (process.platform === 'win32') {
+    // Passed via the environment so no quoting of `content` is ever required.
+    spawnSync('powershell.exe', ['-NoProfile', '-Command', 'Set-Clipboard -Value $env:CLIP_TEXT'], {
+      env: { ...process.env, CLIP_TEXT: content },
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    return;
+  }
+  if (process.platform === 'darwin') {
+    spawnSync('pbcopy', [], { input: content, stdio: ['pipe', 'ignore', 'ignore'] });
+    return;
+  }
+  spawnSync('xclip', ['-selection', 'clipboard'], {
+    input: content,
+    stdio: ['pipe', 'ignore', 'ignore'],
+  });
+}
+
+/** Escape a JS string for embedding in an AppleScript string literal. */
+function escapeAppleScript(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+let notificationWarningShown = false;
+
+/** Reset the once-per-process "notifier missing" warning latch (used by tests). */
+export function resetNotificationWarning(): void {
+  notificationWarningShown = false;
+}
+
+export function sendNotification(
+  title: string,
+  message: string,
+  warnFn: (msg: string) => void = console.error,
+): void {
+  const tool = notificationTool();
+  if (!isCommandAvailable(tool)) {
+    if (!notificationWarningShown) {
+      notificationWarningShown = true;
+      warnFn(
+        `[watch] Desktop notifications disabled: \`${tool}\` was not found on your PATH. ${installHint(tool)}`,
+      );
     }
-  } catch {}
+    return;
+  }
+
+  if (process.platform === 'darwin') {
+    const script = `display notification "${escapeAppleScript(message)}" with title "${escapeAppleScript(title)}"`;
+    spawnSync('osascript', ['-e', script], { stdio: 'ignore' });
+    return;
+  }
+
+  if (process.platform === 'win32') {
+    // Title/message travel via the environment; the script body stays constant.
+    const psCmd =
+      "[reflection.assembly]::loadwithpartialname('System.Windows.Forms'); " +
+      '$notify = new-object system.windows.forms.notifyicon; ' +
+      '$notify.icon = [system.drawing.systemicons]::information; ' +
+      '$notify.visible = $true; ' +
+      '$notify.showballoontip(3000, $env:PS_NOTIFY_TITLE, $env:PS_NOTIFY_MESSAGE, [system.windows.forms.tooltipicon]::info)';
+    spawnSync('powershell.exe', ['-NoProfile', '-Command', psCmd], {
+      env: { ...process.env, PS_NOTIFY_TITLE: title, PS_NOTIFY_MESSAGE: message },
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    return;
+  }
+
+  // `--` stops notify-send treating a title/message beginning with `-` as a flag.
+  spawnSync('notify-send', ['--', title, message], { stdio: 'ignore' });
 }
 
 export function formatNotificationMessage(sessionMap?: Record<string, string>): string {
@@ -83,20 +175,24 @@ export function formatNotificationMessage(sessionMap?: Record<string, string>): 
   return `Scrubbed ${parts.join(', ')}`;
 }
 
+interface WatchStepOptions {
+  sessionId?: string;
+  disable?: string;
+  enable?: string;
+  strictName?: boolean;
+  codeTellTerms?: string;
+  urlAllowlist?: string;
+  dryRun?: boolean;
+  backup?: boolean;
+  readClipboardFn?: () => string;
+  writeClipboardFn?: (text: string) => void;
+  logFn?: (msg: string) => void;
+  notifyFn?: (title: string, msg: string) => void;
+}
+
 export async function watchClipboardStep(
   lastContent: string,
-  options: {
-    sessionId?: string;
-    disable?: string;
-    enable?: string;
-    strictName?: boolean;
-    codeTellTerms?: string;
-    urlAllowlist?: string;
-    readClipboardFn?: () => string;
-    writeClipboardFn?: (text: string) => void;
-    logFn?: (msg: string) => void;
-    notifyFn?: (title: string, msg: string) => void;
-  },
+  options: WatchStepOptions,
 ): Promise<string> {
   const readFn = options.readClipboardFn ?? readClipboard;
   const writeFn = options.writeClipboardFn ?? writeClipboard;
@@ -109,8 +205,12 @@ export async function watchClipboardStep(
     // Watch mode only handles string content
     const scrubbed = typeof result.scrubbedContent === 'string' ? result.scrubbedContent : current;
     if (scrubbed !== current) {
-      writeFn(scrubbed);
       const msg = formatNotificationMessage(result.sessionMap);
+      if (options.dryRun) {
+        log(`[watch] (dry-run) Would have ${msg.toLowerCase()} from clipboard.`);
+        return current;
+      }
+      writeFn(scrubbed);
       log(`[watch] ${msg} from clipboard.`);
       notify('prompt-scrub', msg);
       return scrubbed;
@@ -123,16 +223,7 @@ export async function watchClipboardStep(
 export async function watchFileStep(
   filePath: string,
   lastContent: string,
-  options: {
-    sessionId?: string;
-    disable?: string;
-    enable?: string;
-    strictName?: boolean;
-    codeTellTerms?: string;
-    urlAllowlist?: string;
-    logFn?: (msg: string) => void;
-    notifyFn?: (title: string, msg: string) => void;
-  },
+  options: WatchStepOptions,
 ): Promise<string> {
   const log = options.logFn ?? console.log;
   const notify = options.notifyFn ?? sendNotification;
@@ -145,8 +236,17 @@ export async function watchFileStep(
     // Watch mode only handles string content
     const scrubbed = typeof result.scrubbedContent === 'string' ? result.scrubbedContent : current;
     if (scrubbed !== current) {
-      writeFileSync(filePath, scrubbed, 'utf8');
       const msg = formatNotificationMessage(result.sessionMap);
+      if (options.dryRun) {
+        log(`[watch] (dry-run) Would have ${msg.toLowerCase()} in ${filePath}.`);
+        return current;
+      }
+      if (options.backup) {
+        const backupPath = `${filePath}.bak`;
+        copyFileSync(filePath, backupPath);
+        log(`[watch] Backed up ${filePath} to ${backupPath}.`);
+      }
+      writeFileSync(filePath, scrubbed, 'utf8');
       log(`[watch] ${msg} in ${filePath}.`);
       notify('prompt-scrub', `${msg} in ${filePath}`);
       return scrubbed;
@@ -156,33 +256,37 @@ export async function watchFileStep(
   return lastContent;
 }
 
-export async function handleWatch(options: {
-  clipboard?: boolean;
-  file?: string | string[];
-  interval?: string;
-  once?: boolean;
-  sessionId?: string;
-  disable?: string;
-  enable?: string;
-  strictName?: boolean;
-  codeTellTerms?: string;
-  urlAllowlist?: string;
-  readClipboardFn?: () => string;
-  writeClipboardFn?: (text: string) => void;
-  logFn?: (msg: string) => void;
-  notifyFn?: (title: string, msg: string) => void;
-}) {
+export async function handleWatch(
+  options: WatchStepOptions & {
+    clipboard?: boolean;
+    file?: string | string[];
+    interval?: string;
+    once?: boolean;
+    onStop?: () => void;
+  },
+) {
   if (!options.clipboard && !options.file) {
     throw new Error('Must specify --clipboard or --file <file>');
   }
 
+  const log = options.logFn ?? console.log;
   const intervalMs = Number.parseInt(options.interval || '1000', 10) || 1000;
+
+  // Only preflight the real clipboard path; injected mocks need no external tool.
+  if (options.clipboard && !options.readClipboardFn) {
+    assertClipboardSupport();
+  }
+
   const readFn = options.readClipboardFn ?? readClipboard;
   let lastClip = options.clipboard ? readFn() : '';
 
   const files = options.file ? (Array.isArray(options.file) ? options.file : [options.file]) : [];
 
   const lastFileContents: Record<string, string> = {};
+
+  if (options.dryRun) {
+    log('[watch] Dry-run mode: no clipboard or file content will be written.');
+  }
 
   const tick = async () => {
     if (options.clipboard) {
@@ -203,6 +307,22 @@ export async function handleWatch(options: {
     tick().catch(() => {});
   }, intervalMs);
 
+  // Ctrl-C must stop the poll loop and exit cleanly rather than leaving the
+  // interval pending. `onStop` lets tests observe this without exiting.
+  const stop = () => {
+    clearInterval(timer);
+    process.removeListener('SIGINT', stop);
+    process.removeListener('SIGTERM', stop);
+    log('[watch] Stopped watching.');
+    if (options.onStop) {
+      options.onStop();
+      return;
+    }
+    process.exit(0);
+  };
+  process.on('SIGINT', stop);
+  process.on('SIGTERM', stop);
+
   return timer;
 }
 
@@ -214,6 +334,8 @@ export function setupWatchCommand(program: Command) {
     .option('-f, --file <files...>', 'File(s) to monitor')
     .option('-i, --interval <ms>', 'Polling interval in milliseconds', '1000')
     .option('--once', 'Run a single check pass and exit')
+    .option('--dry-run', 'Report what would be scrubbed without writing any changes')
+    .option('--backup', 'Write <file>.bak before overwriting a watched file')
     .option('--session-id <id>', 'Resume or target a specific session')
     .option('--disable <detectors>', 'Comma-separated list of detector names to skip')
     .option('--enable <detectors>', 'Comma-separated list of off-by-default detectors to enable')

--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -1,0 +1,231 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import type { Command } from 'commander';
+import { handleScrub } from './scrub.js';
+
+export function readClipboard(): string {
+  try {
+    if (process.platform === 'win32') {
+      return execSync('powershell.exe -NoProfile -Command Get-Clipboard', {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'ignore'],
+      }).replace(/\r\n$/, '');
+    }
+    if (process.platform === 'darwin') {
+      return execSync('pbpaste', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] });
+    }
+    return execSync('xclip -selection clipboard -o', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+  } catch {
+    return '';
+  }
+}
+
+export function writeClipboard(content: string): void {
+  try {
+    if (process.platform === 'win32') {
+      execSync(
+        'powershell.exe -NoProfile -Command "Set-Clipboard -Value ([Environment]::GetEnvironmentVariable(\'CLIP_TEXT\'))"',
+        {
+          env: { ...process.env, CLIP_TEXT: content },
+          stdio: ['pipe', 'pipe', 'ignore'],
+        },
+      );
+      return;
+    }
+    if (process.platform === 'darwin') {
+      execSync('pbcopy', { input: content, stdio: ['pipe', 'pipe', 'ignore'] });
+      return;
+    }
+    execSync('xclip -selection clipboard', { input: content, stdio: ['pipe', 'pipe', 'ignore'] });
+  } catch {}
+}
+
+export function sendNotification(title: string, message: string): void {
+  try {
+    if (process.platform === 'darwin') {
+      execSync(`osascript -e 'display notification "${message}" with title "${title}"'`, {
+        stdio: ['pipe', 'pipe', 'ignore'],
+      });
+    } else if (process.platform === 'win32') {
+      const psCmd = `[reflection.assembly]::loadwithpartialname('System.Windows.Forms'); $notify = new-object system.windows.forms.notifyicon; $notify.icon = [system.drawing.systemicons]::information; $notify.visible = $true; $notify.showballoontip(3000, '${title}', '${message}', [system.windows.forms.tooltipicon]::info)`;
+      execSync(`powershell.exe -NoProfile -Command "${psCmd}"`, {
+        stdio: ['pipe', 'pipe', 'ignore'],
+      });
+    } else if (process.platform === 'linux') {
+      execSync(`notify-send "${title}" "${message}"`, {
+        stdio: ['pipe', 'pipe', 'ignore'],
+      });
+    }
+  } catch {}
+}
+
+export function formatNotificationMessage(sessionMap?: Record<string, string>): string {
+  if (!sessionMap) return 'Scrubbed 0 items';
+  const keys = Object.keys(sessionMap);
+  if (keys.length === 0) return 'Scrubbed 0 items';
+
+  const counts: Record<string, number> = {};
+  for (const key of keys) {
+    const cleanKey = key.replace(/[«»]/g, '');
+    const prefix = cleanKey.split('_')[0] || 'item';
+    const category = prefix.toLowerCase();
+    counts[category] = (counts[category] || 0) + 1;
+  }
+
+  const parts = Object.entries(counts).map(([cat, cnt]) => {
+    const name = cnt === 1 ? cat : `${cat}s`;
+    return `${cnt} ${name}`;
+  });
+
+  return `Scrubbed ${parts.join(', ')}`;
+}
+
+export async function watchClipboardStep(
+  lastContent: string,
+  options: {
+    sessionId?: string;
+    disable?: string;
+    enable?: string;
+    strictName?: boolean;
+    codeTellTerms?: string;
+    urlAllowlist?: string;
+    readClipboardFn?: () => string;
+    writeClipboardFn?: (text: string) => void;
+    logFn?: (msg: string) => void;
+    notifyFn?: (title: string, msg: string) => void;
+  },
+): Promise<string> {
+  const readFn = options.readClipboardFn ?? readClipboard;
+  const writeFn = options.writeClipboardFn ?? writeClipboard;
+  const log = options.logFn ?? console.log;
+  const notify = options.notifyFn ?? sendNotification;
+
+  const current = readFn();
+  if (current && current !== lastContent) {
+    const result = await handleScrub(current, options);
+    // Watch mode only handles string content
+    const scrubbed = typeof result.scrubbedContent === 'string' ? result.scrubbedContent : current;
+    if (scrubbed !== current) {
+      writeFn(scrubbed);
+      const msg = formatNotificationMessage(result.sessionMap);
+      log(`[watch] ${msg} from clipboard.`);
+      notify('prompt-scrub', msg);
+      return scrubbed;
+    }
+    return current;
+  }
+  return lastContent;
+}
+
+export async function watchFileStep(
+  filePath: string,
+  lastContent: string,
+  options: {
+    sessionId?: string;
+    disable?: string;
+    enable?: string;
+    strictName?: boolean;
+    codeTellTerms?: string;
+    urlAllowlist?: string;
+    logFn?: (msg: string) => void;
+    notifyFn?: (title: string, msg: string) => void;
+  },
+): Promise<string> {
+  const log = options.logFn ?? console.log;
+  const notify = options.notifyFn ?? sendNotification;
+  if (!existsSync(filePath)) {
+    return lastContent;
+  }
+  const current = readFileSync(filePath, 'utf8');
+  if (current !== lastContent) {
+    const result = await handleScrub(current, options);
+    // Watch mode only handles string content
+    const scrubbed = typeof result.scrubbedContent === 'string' ? result.scrubbedContent : current;
+    if (scrubbed !== current) {
+      writeFileSync(filePath, scrubbed, 'utf8');
+      const msg = formatNotificationMessage(result.sessionMap);
+      log(`[watch] ${msg} in ${filePath}.`);
+      notify('prompt-scrub', `${msg} in ${filePath}`);
+      return scrubbed;
+    }
+    return current;
+  }
+  return lastContent;
+}
+
+export async function handleWatch(options: {
+  clipboard?: boolean;
+  file?: string | string[];
+  interval?: string;
+  once?: boolean;
+  sessionId?: string;
+  disable?: string;
+  enable?: string;
+  strictName?: boolean;
+  codeTellTerms?: string;
+  urlAllowlist?: string;
+  readClipboardFn?: () => string;
+  writeClipboardFn?: (text: string) => void;
+  logFn?: (msg: string) => void;
+  notifyFn?: (title: string, msg: string) => void;
+}) {
+  if (!options.clipboard && !options.file) {
+    throw new Error('Must specify --clipboard or --file <file>');
+  }
+
+  const intervalMs = Number.parseInt(options.interval || '1000', 10) || 1000;
+  const readFn = options.readClipboardFn ?? readClipboard;
+  let lastClip = options.clipboard ? readFn() : '';
+
+  const files = options.file ? (Array.isArray(options.file) ? options.file : [options.file]) : [];
+
+  const lastFileContents: Record<string, string> = {};
+
+  const tick = async () => {
+    if (options.clipboard) {
+      lastClip = await watchClipboardStep(lastClip, options);
+    }
+    for (const f of files) {
+      lastFileContents[f] = await watchFileStep(f, lastFileContents[f] ?? '', options);
+    }
+  };
+
+  await tick();
+
+  if (options.once) {
+    return;
+  }
+
+  const timer = setInterval(() => {
+    tick().catch(() => {});
+  }, intervalMs);
+
+  return timer;
+}
+
+export function setupWatchCommand(program: Command) {
+  program
+    .command('watch')
+    .description('Monitor system clipboard or specific files and automatically scrub content')
+    .option('-c, --clipboard', 'Monitor system clipboard')
+    .option('-f, --file <files...>', 'File(s) to monitor')
+    .option('-i, --interval <ms>', 'Polling interval in milliseconds', '1000')
+    .option('--once', 'Run a single check pass and exit')
+    .option('--session-id <id>', 'Resume or target a specific session')
+    .option('--disable <detectors>', 'Comma-separated list of detector names to skip')
+    .option('--enable <detectors>', 'Comma-separated list of off-by-default detectors to enable')
+    .option('--strict-name', 'Enable strict allowlisting for NameDetector')
+    .option('--code-tell-terms <terms>', 'Comma-separated list of private terms to detect')
+    .option('--url-allowlist <hosts>', 'Comma-separated list of hostnames to pass-through')
+    .action(async (options) => {
+      try {
+        await handleWatch(options);
+      } catch (err: unknown) {
+        console.error((err as Error).message);
+        process.exit(1);
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,6 +10,7 @@ import { setupRehydrateCommand } from './commands/rehydrate.js';
 import { setupRulesCommands } from './commands/rules.js';
 import { setupScrubCommand } from './commands/scrub.js';
 import { setupSessionsCommands } from './commands/sessions.js';
+import { setupWatchCommand } from './commands/watch.js';
 
 // Get version from package.json
 const __filename = fileURLToPath(import.meta.url);
@@ -41,6 +42,7 @@ setupInspectCommand(program);
 setupSessionsCommands(program);
 setupRulesCommands(program);
 setupConfigCommands(program);
+setupWatchCommand(program);
 
 if (process.argv[1] === __filename) {
   program.parseAsync(process.argv).catch((err) => {

--- a/tests/cli/watch.test.ts
+++ b/tests/cli/watch.test.ts
@@ -1,0 +1,141 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'ava';
+import {
+  formatNotificationMessage,
+  handleWatch,
+  watchClipboardStep,
+  watchFileStep,
+} from '../../src/cli/commands/watch.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const tmpDir = path.join(__dirname, '.tmp-cli-watch-full');
+
+test.before(() => {
+  process.env.PROMPT_SCRUB_CONFIG_DIR = tmpDir;
+  if (!fs.existsSync(tmpDir)) {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  }
+});
+
+test.after.always(() => {
+  if (fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('formatNotificationMessage correctly formats single and plural categories', (t) => {
+  t.is(formatNotificationMessage(undefined), 'Scrubbed 0 items');
+  t.is(formatNotificationMessage({}), 'Scrubbed 0 items');
+  t.is(formatNotificationMessage({ Secret_1: 'val1', Secret_2: 'val2' }), 'Scrubbed 2 secrets');
+  t.is(
+    formatNotificationMessage({ Secret_1: 'val1', Email_1: 'val2' }),
+    'Scrubbed 1 secret, 1 email',
+  );
+});
+
+test('watchClipboardStep scrubs sensitive data, logs, and triggers notification', async (t) => {
+  let written = '';
+  let logged = '';
+  let notifiedTitle = '';
+  let notifiedMsg = '';
+
+  const mockRead = () => 'Contact user@example.com immediately';
+  const mockWrite = (text: string) => {
+    written = text;
+  };
+  const mockLog = (msg: string) => {
+    logged = msg;
+  };
+  const mockNotify = (title: string, msg: string) => {
+    notifiedTitle = title;
+    notifiedMsg = msg;
+  };
+
+  const next = await watchClipboardStep('', {
+    readClipboardFn: mockRead,
+    writeClipboardFn: mockWrite,
+    logFn: mockLog,
+    notifyFn: mockNotify,
+  });
+
+  t.is(next, 'Contact «Email_1» immediately');
+  t.is(written, 'Contact «Email_1» immediately');
+  t.true(logged.includes('[watch] Scrubbed 1 email from clipboard.'));
+  t.is(notifiedTitle, 'prompt-scrub');
+  t.is(notifiedMsg, 'Scrubbed 1 email');
+});
+
+test('watchClipboardStep does nothing when clipboard has not changed', async (t) => {
+  let writeCalled = false;
+  const mockRead = () => 'Contact user@example.com immediately';
+  const mockWrite = () => {
+    writeCalled = true;
+  };
+
+  const current = 'Contact user@example.com immediately';
+  const next = await watchClipboardStep(current, {
+    readClipboardFn: mockRead,
+    writeClipboardFn: mockWrite,
+  });
+
+  t.is(next, current);
+  t.false(writeCalled);
+});
+
+test('watchFileStep scrubs file content when file changes and triggers notification', async (t) => {
+  const filePath = path.join(tmpDir, 'test-watch-file.txt');
+  fs.writeFileSync(filePath, 'Send key sk-1234567890abcdef1234567890abcdef here', 'utf8');
+
+  let logged = '';
+  let notifiedMsg = '';
+  const mockLog = (msg: string) => {
+    logged = msg;
+  };
+  const mockNotify = (_title: string, msg: string) => {
+    notifiedMsg = msg;
+  };
+
+  const next = await watchFileStep(filePath, '', {
+    logFn: mockLog,
+    notifyFn: mockNotify,
+  });
+
+  t.is(next, 'Send key «Secret_1» here');
+  t.is(fs.readFileSync(filePath, 'utf8'), 'Send key «Secret_1» here');
+  t.true(logged.includes('[watch] Scrubbed 1 secret in'));
+  t.true(notifiedMsg.includes('Scrubbed 1 secret in'));
+});
+
+test('handleWatch supports watching multiple files', async (t) => {
+  const file1 = path.join(tmpDir, 'f1.txt');
+  const file2 = path.join(tmpDir, 'f2.txt');
+  fs.writeFileSync(file1, 'Email: alice@example.com', 'utf8');
+  fs.writeFileSync(file2, 'Key: sk-1234567890abcdef1234567890abcdef', 'utf8');
+
+  let logCount = 0;
+  const mockLog = () => {
+    logCount++;
+  };
+
+  await handleWatch({
+    file: [file1, file2],
+    once: true,
+    logFn: mockLog,
+  });
+
+  t.is(fs.readFileSync(file1, 'utf8'), 'Email: «Email_1»');
+  t.is(fs.readFileSync(file2, 'utf8'), 'Key: «Secret_1»');
+  t.is(logCount, 2);
+});
+
+test('handleWatch throws when neither --clipboard nor --file is provided', async (t) => {
+  await t.throwsAsync(
+    async () => {
+      await handleWatch({});
+    },
+    { message: 'Must specify --clipboard or --file <file>' },
+  );
+});

--- a/tests/cli/watch.test.ts
+++ b/tests/cli/watch.test.ts
@@ -3,8 +3,14 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'ava';
 import {
+  assertClipboardSupport,
+  clipboardTool,
   formatNotificationMessage,
   handleWatch,
+  isCommandAvailable,
+  notificationTool,
+  resetNotificationWarning,
+  sendNotification,
   watchClipboardStep,
   watchFileStep,
 } from '../../src/cli/commands/watch.js';
@@ -138,4 +144,148 @@ test('handleWatch throws when neither --clipboard nor --file is provided', async
     },
     { message: 'Must specify --clipboard or --file <file>' },
   );
+});
+
+test('isCommandAvailable detects present and absent binaries', (t) => {
+  t.true(isCommandAvailable(process.platform === 'win32' ? 'where.exe' : 'sh'));
+  t.false(isCommandAvailable('prompt-scrub-definitely-not-a-real-binary'));
+});
+
+test('clipboardTool and notificationTool resolve a binary for this platform', (t) => {
+  t.true(clipboardTool().length > 0);
+  t.true(notificationTool().length > 0);
+});
+
+test('assertClipboardSupport passes when the platform clipboard tool exists', (t) => {
+  if (isCommandAvailable(clipboardTool())) {
+    t.notThrows(() => assertClipboardSupport());
+  } else {
+    t.throws(() => assertClipboardSupport(), { message: /was not found on your PATH/ });
+  }
+});
+
+test('sendNotification warns once instead of silently failing when the tool is missing', (t) => {
+  resetNotificationWarning();
+  const warnings: string[] = [];
+  const collect = (msg: string) => {
+    warnings.push(msg);
+  };
+
+  if (isCommandAvailable(notificationTool())) {
+    t.pass('notifier present on this machine; missing-tool path covered on CI runners without it');
+    return;
+  }
+
+  sendNotification('prompt-scrub', 'Scrubbed 1 email', collect);
+  sendNotification('prompt-scrub', 'Scrubbed 1 email', collect);
+
+  t.is(warnings.length, 1);
+  t.true(warnings[0]?.includes('Desktop notifications disabled'));
+});
+
+test('sendNotification does not execute shell metacharacters in the message', (t) => {
+  resetNotificationWarning();
+  const marker = path.join(tmpDir, 'pwned.txt');
+  const posixMarker = marker.split(path.sep).join('/');
+  // Mixes command substitution, backticks and a bare apostrophe - the three
+  // things that broke the old execSync string interpolation.
+  const injected = [
+    'Scrubbed 1 secret in',
+    `$(node -e "require('fs').writeFileSync('${posixMarker}','x')")`,
+    `\`node -e "require('fs').writeFileSync('${posixMarker}','x')"\``,
+    "it's.txt",
+  ].join(' ');
+
+  t.notThrows(() => sendNotification('prompt-scrub', injected, () => {}));
+  t.false(fs.existsSync(marker), 'command substitution in the message must not run');
+});
+
+test('watchFileStep with dryRun reports without writing the file', async (t) => {
+  const filePath = path.join(tmpDir, 'dry-run.txt');
+  const original = 'Contact user@example.com immediately';
+  fs.writeFileSync(filePath, original, 'utf8');
+
+  const logs: string[] = [];
+  let notified = false;
+
+  const next = await watchFileStep(filePath, '', {
+    dryRun: true,
+    logFn: (msg) => {
+      logs.push(msg);
+    },
+    notifyFn: () => {
+      notified = true;
+    },
+  });
+
+  t.is(fs.readFileSync(filePath, 'utf8'), original, 'file must be left untouched');
+  t.is(next, original);
+  t.false(notified, 'dry-run must not fire a notification');
+  t.true(logs.some((l) => l.includes('(dry-run)')));
+});
+
+test('watchClipboardStep with dryRun reports without writing the clipboard', async (t) => {
+  let writeCalled = false;
+  const logs: string[] = [];
+
+  const next = await watchClipboardStep('', {
+    dryRun: true,
+    readClipboardFn: () => 'Contact user@example.com immediately',
+    writeClipboardFn: () => {
+      writeCalled = true;
+    },
+    logFn: (msg) => {
+      logs.push(msg);
+    },
+    notifyFn: () => {},
+  });
+
+  t.false(writeCalled, 'dry-run must not write the clipboard');
+  t.is(next, 'Contact user@example.com immediately');
+  t.true(logs.some((l) => l.includes('(dry-run)')));
+});
+
+test('watchFileStep with backup writes <file>.bak holding the original content', async (t) => {
+  const filePath = path.join(tmpDir, 'backup-me.txt');
+  const original = 'Contact user@example.com immediately';
+  fs.writeFileSync(filePath, original, 'utf8');
+
+  await watchFileStep(filePath, '', {
+    backup: true,
+    logFn: () => {},
+    notifyFn: () => {},
+  });
+
+  t.is(fs.readFileSync(filePath, 'utf8'), 'Contact «Email_1» immediately');
+  t.true(fs.existsSync(`${filePath}.bak`));
+  t.is(fs.readFileSync(`${filePath}.bak`, 'utf8'), original, 'backup keeps pre-scrub content');
+});
+
+test('handleWatch registers a SIGINT handler that clears the timer and stops', async (t) => {
+  const filePath = path.join(tmpDir, 'sigint.txt');
+  fs.writeFileSync(filePath, 'nothing sensitive here', 'utf8');
+
+  const before = process.listenerCount('SIGINT');
+  let stopped = false;
+
+  const timer = await handleWatch({
+    file: filePath,
+    interval: '50',
+    logFn: () => {},
+    notifyFn: () => {},
+    onStop: () => {
+      stopped = true;
+    },
+  });
+
+  t.is(process.listenerCount('SIGINT'), before + 1, 'SIGINT handler is registered');
+
+  process.emit('SIGINT');
+
+  t.true(stopped, 'SIGINT invokes the stop path');
+  t.is(process.listenerCount('SIGINT'), before, 'handler is removed again on stop');
+
+  if (timer) {
+    clearInterval(timer);
+  }
 });


### PR DESCRIPTION
## Description

Implements watch mode for real-time clipboard and file monitoring with automatic scrubbing.
Solves the copy-paste workflow for users who interact with LLMs through web interfaces like ChatGPT or Claude.

Closes #99

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Testing Notes

**Automated tests:**
- [x] 15 new tests added (watch.test.ts, watch-integration.test.ts)
- [x] All tests passing
- [x] Tests cover clipboard monitoring, file watching, session persistence, detector control, error handling

**Manual verification:**
- [x] Tested `prompt-scrub watch --clipboard --once`
- [x] Tested `prompt-scrub watch --file test.txt --once`
- [x] Verified scrubbing of emails, secrets, paths, URLs, phone numbers
- [x] Confirmed desktop notifications work
- [x] Cross-platform build verified

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] I have self-reviewed my code.
- [x] I have formatted, linted, and passed all tests (`pnpm run check`).
- [x] I have added/updated documentation if necessary.
- [x] I have added/updated tests if necessary.
- [x] I have NOT bumped the version in `package.json` (maintainers will handle this).