### PR TITLE
fix: detect common names in strict mode

### DIFF
--- a/src/detectors/name.ts
+++ b/src/detectors/name.ts
@@ -4,18 +4,9 @@ import type { Detector, Finding } from '../types/index.js';
 // e.g., "Alice", "John Doe", "San Francisco"
 const NAME_REGEX = /\b[A-Z][a-z]+(?: [A-Z][a-z]+)*\b/g;
 
-// A small built-in allowlist for strict mode covering common first names, countries,
-// languages, and widely recognized product names.
+// A small built-in allowlist for strict mode covering countries, languages,
+// and widely recognized product names.
 const ALLOWLIST = new Set([
-  // Common first names
-  'john',
-  'jane',
-  'michael',
-  'sarah',
-  'david',
-  'emily',
-  'james',
-  'jessica',
   // Countries
   'united states',
   'canada',

--- a/tests/cli/scrub.test.ts
+++ b/tests/cli/scrub.test.ts
@@ -50,12 +50,11 @@ test('handleScrub respects enabled detectors', async (t) => {
 });
 
 test('handleScrub respects strictName option', async (t) => {
-  const result = await handleScrub('Hello John.', {
+  const result = await handleScrub('hello John.', {
     enable: 'NameDetector',
     strictName: true,
   });
-  // 'John' is in the allowlist, so it should not be scrubbed in strict mode
-  t.is(result.scrubbedContent, 'Hello John.');
+  t.is(result.scrubbedContent, 'hello «Name_1».');
 });
 
 test('handleScrub respects codeTellTerms', async (t) => {

--- a/tests/core/scrub.test.ts
+++ b/tests/core/scrub.test.ts
@@ -192,7 +192,7 @@ test('NameDetector works when explicitly enabled', (t) => {
 });
 
 test('NameDetector works in strict mode', (t) => {
-  // 'John' and 'London' (not in allowlist) vs allowlisted 'France'
+  // Names and unknown proper nouns are detected, while allowlisted countries are not.
   const text = 'John visited France and London.';
   const scrubbed = scrub({
     content: text,
@@ -202,9 +202,7 @@ test('NameDetector works in strict mode', (t) => {
     },
   });
 
-  // France is allowlisted, John is allowlisted (wait, 'John' is in allowlist!).
-  // London is not allowlisted.
-  t.is(scrubbed.scrubbedContent, 'John visited France and «Name_1».');
+  t.is(scrubbed.scrubbedContent, '«Name_2» visited France and «Name_1».');
 });
 
 test('NameDetector round-trips correctly', (t) => {

--- a/tests/detectors/name.test.ts
+++ b/tests/detectors/name.test.ts
@@ -35,9 +35,10 @@ test('detects multiple names', (t) => {
 
 // --- Strict Mode Cases ---
 
-test('strict mode skips allowlisted first names', (t) => {
-  const findings = strictDetector.detect('John went to the store with Jane.');
-  t.is(findings.length, 0); // John and Jane are allowlisted
+test('strict mode detects common names while skipping allowlisted companies', (t) => {
+  const findings = strictDetector.detect('John Doe works at Google.');
+  t.is(findings.length, 1);
+  t.is(findings[0]?.value, 'John Doe');
 });
 
 test('strict mode skips allowlisted countries and languages', (t) => {


### PR DESCRIPTION
## Description

Strict mode skips matches containing an allowlisted word. Since the allowlist includes common first names, a match such as `John Doe` can pass through without being scrubbed.

This removes common first names from the allowlist while keeping countries, languages, company names, days, and months. The detector, core, and CLI tests now cover the corrected behavior.

Fixes #84.

Related: #102 also addresses this issue. This version keeps the core expectation aligned with right-to-left placeholder creation and uses lowercase `hello` in the CLI fixture so the test isolates `John` instead of matching `Hello John` as one capitalized phrase.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing Notes

- Ran `pnpm run check`.
- All 205 automated tests passed.
- Formatting, type checking, linting, Knip, and dependency audit passed.
- `test:security` was skipped by the repository script because Semgrep is not installed locally.

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] I have self-reviewed my code.
- [x] I have formatted, linted, and passed all tests (`pnpm run check`).
- [x] I have added/updated documentation if necessary.
- [x] I have added/updated tests if necessary.
- [x] I have NOT bumped the version in `package.json` (maintainers will handle this).
