### PR TITLE
feat(cli): add init and config show commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@ const { content } = rehydrate({
 console.log(content); // "I see your key is sk-12345"
 ```
 
+## Configuration
+
+`prompt-scrub` reads an optional config file for extra rule packs and URL allowlisting. Create one pre-filled with the default schema:
+
+```bash
+prompt-scrub init
+# Created config file at /home/alice/.config/prompt-scrub/config.json
+```
+
+Print the configuration that is actually active — JSON on `stdout`, the path it came from on `stderr`:
+
+```bash
+prompt-scrub config show
+```
+
+Entries that do not match the schema are reported and exit non-zero, so `config show` doubles as a config check in scripts. See the [CLI reference](docs/getting-started/cli.md#configuration) for the full schema and options.
+
 ## Documentation
 
 Full user guides and architecture details are in the [`docs/`](docs/) directory:

--- a/docs/features/authoring-rule-packs.md
+++ b/docs/features/authoring-rule-packs.md
@@ -90,12 +90,11 @@ Let's build a rule pack that detects "Project X" codenames.
    ```
 
 4. **Configuration**:
-   Users can then add it to their `package.json` in their project:
+   Users can then add it to their configuration file (`prompt-scrub init` creates one):
    ```json
    {
-     "prompt-scrub": {
-       "rulePacks": ["prompt-scrub-projectx"]
-     }
+     "rulePacks": ["prompt-scrub-projectx"],
+     "urlAllowlist": []
    }
    ```
 

--- a/docs/features/detectors.md
+++ b/docs/features/detectors.md
@@ -80,15 +80,16 @@ prompt-scrubber supports distributing rule packs as standalone npm packages. A r
 
 To use a rule pack:
 1. Install it via npm: `npm install some-rule-pack`
-2. Declare it in your configuration. You can do this by adding a `prompt-scrub.rulePacks` array to your local `package.json`, or globally in `~/.config/prompt-scrub/config.json`.
+2. Declare it in your configuration file. Run `prompt-scrub init` to create one, then add the package name to `rulePacks`:
 
 ```json
 {
-  "prompt-scrub": {
-    "rulePacks": ["some-rule-pack"]
-  }
+  "rulePacks": ["some-rule-pack"],
+  "urlAllowlist": []
 }
 ```
+
+Run `prompt-scrub config show` to confirm the tool picked it up.
 
 Once declared, the CLI will automatically discover, load, and merge these detectors into the active set on startup. They participate natively in collision resolution and can be inspected via `prompt-scrub rules list`.
 

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -44,6 +44,58 @@ Prints the raw JSON contents of a session map for inspection or manual editing.
 ### `prompt-scrub sessions rm <id>`
 Deletes a session map from the disk permanently.
 
+## Configuration
+
+### `prompt-scrub init`
+Creates a configuration file with the default (empty) schema at the OS config path (`~/.config/prompt-scrub/config.json` on Linux, `~/Library/Application Support/prompt-scrub/config.json` on macOS, `%APPDATA%\prompt-scrub\config.json` on Windows). Parent directories are created if needed. Set `PROMPT_SCRUB_CONFIG_DIR` to relocate the config directory on any platform.
+
+```bash
+$ prompt-scrub init
+Created config file at /home/alice/.config/prompt-scrub/config.json
+```
+
+The generated file documents the supported schema:
+
+```json
+{
+  "rulePacks": [],
+  "urlAllowlist": []
+}
+```
+
+- `rulePacks`: npm package names to load extra detectors from. See [Authoring Rule Packs](../features/authoring-rule-packs.md).
+- `urlAllowlist`: hostnames the `UrlDetector` passes through unchanged. Subdomains are implicitly allowed.
+
+Fails if a config file already exists.
+
+**Options:**
+- `--force`: Overwrite the existing configuration file.
+
+### `prompt-scrub config show`
+Prints the active configuration as JSON on `stdout`, and the path it was read from on `stderr`. If no config file exists, the defaults are printed instead.
+
+```bash
+$ prompt-scrub config show
+Config file: /home/alice/.config/prompt-scrub/config.json
+{
+  "rulePacks": ["prompt-scrub-projectx"],
+  "urlAllowlist": ["example.com"]
+}
+```
+
+Entries that do not match the schema are reported on `stderr` and the command exits with code `1`, so it can be used as a config check in scripts. Invalid entries are ignored at runtime rather than failing the scrub:
+
+```bash
+$ prompt-scrub config show
+Config file: /home/alice/.config/prompt-scrub/config.json
+  error: Unknown key "rulePaks". Supported keys: rulePacks, urlAllowlist.
+{
+  "rulePacks": [],
+  "urlAllowlist": []
+}
+Invalid entries are ignored at runtime.
+```
+
 ## Utility
 
 ### `prompt-scrub --version`

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -78,8 +78,12 @@ Prints the active configuration as JSON on `stdout`, and the path it was read fr
 $ prompt-scrub config show
 Config file: /home/alice/.config/prompt-scrub/config.json
 {
-  "rulePacks": ["prompt-scrub-projectx"],
-  "urlAllowlist": ["example.com"]
+  "rulePacks": [
+    "prompt-scrub-projectx"
+  ],
+  "urlAllowlist": [
+    "example.com"
+  ]
 }
 ```
 

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,0 +1,58 @@
+import type { Command } from 'commander';
+import { createDefaultConfig, readConfigFile, writeConfig } from '../../core/config.js';
+
+export function setupConfigCommands(program: Command) {
+  program
+    .command('init')
+    .description('Create a default configuration file')
+    .option('--force', 'Overwrite an existing configuration file')
+    .action((options: { force?: boolean }) => {
+      const { path: configPath, exists } = readConfigFile();
+
+      if (exists && !options.force) {
+        console.error(
+          `Config file already exists at ${configPath}. Re-run with --force to overwrite it.`,
+        );
+        process.exit(1);
+        return;
+      }
+
+      try {
+        writeConfig(createDefaultConfig());
+      } catch (err: unknown) {
+        console.error(`Error writing config file: ${(err as Error).message}`);
+        process.exit(1);
+        return;
+      }
+
+      console.log(`Created config file at ${configPath}`);
+    });
+
+  const configCommand = program.command('config').description('Manage the configuration file');
+
+  configCommand
+    .command('show')
+    .description('Print the active configuration')
+    .action(() => {
+      const { path: configPath, exists, errors, config } = readConfigFile();
+
+      if (exists) {
+        console.error(`Config file: ${configPath}`);
+      } else {
+        console.error(
+          `No config file at ${configPath}. Showing defaults — run 'prompt-scrub init' to create one.`,
+        );
+      }
+
+      for (const error of errors) {
+        console.error(`  error: ${error}`);
+      }
+
+      console.log(JSON.stringify(config, null, 2));
+
+      if (errors.length > 0) {
+        console.error('Invalid entries are ignored at runtime.');
+        process.exit(1);
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
+import { setupConfigCommands } from './commands/config.js';
 import { setupInspectCommand } from './commands/inspect.js';
 import { setupRehydrateCommand } from './commands/rehydrate.js';
 import { setupRulesCommands } from './commands/rules.js';
@@ -39,6 +40,7 @@ setupRehydrateCommand(program);
 setupInspectCommand(program);
 setupSessionsCommands(program);
 setupRulesCommands(program);
+setupConfigCommands(program);
 
 if (process.argv[1] === __filename) {
   program.parseAsync(process.argv).catch((err) => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -7,6 +7,22 @@ export interface PromptScrubConfig {
   urlAllowlist?: string[];
 }
 
+export interface ConfigFileState {
+  path: string;
+  exists: boolean;
+  errors: string[];
+  config: PromptScrubConfig;
+}
+
+export function createDefaultConfig(): Required<PromptScrubConfig> {
+  return {
+    rulePacks: [],
+    urlAllowlist: [],
+  };
+}
+
+const CONFIG_KEYS = Object.keys(createDefaultConfig());
+
 /**
  * Determines the base configuration directory based on the OS.
  *
@@ -36,40 +52,97 @@ export function getConfigDir(): string {
   }
 }
 
-/**
- * Reads configuration from ~/.config/prompt-scrub/config.json and local package.json,
- * merging the rulePacks arrays.
- */
-export function loadConfig(): PromptScrubConfig {
-  const config: PromptScrubConfig = {
-    rulePacks: [],
-    urlAllowlist: [],
-  };
+function getConfigPath(): string {
+  return path.join(getConfigDir(), 'config.json');
+}
 
-  const rulePacks = new Set<string>();
-  const urlAllowlist = new Set<string>();
+function describeType(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'an array';
+  return typeof value;
+}
 
-  // 1. Read global config
-  const globalConfigPath = path.join(getConfigDir(), 'config.json');
-  if (fs.existsSync(globalConfigPath)) {
-    try {
-      const globalData = JSON.parse(fs.readFileSync(globalConfigPath, 'utf8'));
-      if (Array.isArray(globalData?.rulePacks)) {
-        for (const pack of globalData.rulePacks) {
-          if (typeof pack === 'string') rulePacks.add(pack);
-        }
-      }
-      if (Array.isArray(globalData?.urlAllowlist)) {
-        for (const host of globalData.urlAllowlist) {
-          if (typeof host === 'string') urlAllowlist.add(host);
-        }
-      }
-    } catch (_e) {
-      // Ignore global config read/parse errors
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return Array.from(new Set(value.filter((item): item is string => typeof item === 'string')));
+}
+
+function validateConfig(data: unknown): string[] {
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    return [`Expected a JSON object, received ${describeType(data)}.`];
+  }
+
+  const errors: string[] = [];
+  const record = data as Record<string, unknown>;
+
+  for (const key of Object.keys(record)) {
+    if (!CONFIG_KEYS.includes(key)) {
+      errors.push(`Unknown key "${key}". Supported keys: ${CONFIG_KEYS.join(', ')}.`);
     }
   }
 
-  config.rulePacks = Array.from(rulePacks);
-  config.urlAllowlist = Array.from(urlAllowlist);
-  return config;
+  for (const key of CONFIG_KEYS) {
+    const value = record[key];
+    if (value === undefined) continue;
+
+    if (!Array.isArray(value)) {
+      errors.push(`"${key}" must be an array of strings, received ${describeType(value)}.`);
+    } else if (value.some((item) => typeof item !== 'string')) {
+      errors.push(`"${key}" must contain only strings.`);
+    }
+  }
+
+  return errors;
+}
+
+export function readConfigFile(): ConfigFileState {
+  const configPath = getConfigPath();
+
+  if (!fs.existsSync(configPath)) {
+    return { path: configPath, exists: false, errors: [], config: createDefaultConfig() };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  } catch (error) {
+    const reason = error instanceof SyntaxError ? 'Invalid JSON' : 'Could not read file';
+    return {
+      path: configPath,
+      exists: true,
+      errors: [`${reason}: ${(error as Error).message}`],
+      config: createDefaultConfig(),
+    };
+  }
+
+  const record =
+    parsed !== null && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+
+  return {
+    path: configPath,
+    exists: true,
+    errors: validateConfig(parsed),
+    config: {
+      rulePacks: toStringArray(record.rulePacks),
+      urlAllowlist: toStringArray(record.urlAllowlist),
+    },
+  };
+}
+
+export function writeConfig(config: PromptScrubConfig): string {
+  const configPath = getConfigPath();
+  fs.mkdirSync(path.dirname(configPath), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+  return configPath;
+}
+
+/**
+ * Reads configuration from ~/.config/prompt-scrub/config.json, dropping any
+ * entries that do not match the schema.
+ */
+export function loadConfig(): PromptScrubConfig {
+  return readConfigFile().config;
 }

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -1,0 +1,251 @@
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'ava';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const cliEntry = path.resolve(__dirname, '../../src/cli/index.ts');
+const tmpRoot = path.join(__dirname, '.tmp-config-cmd');
+
+let counter = 0;
+
+function makeConfigDir(): string {
+  counter += 1;
+  const dir = path.join(tmpRoot, `case-${counter}`, 'prompt-scrub');
+  fs.rmSync(dir, { recursive: true, force: true });
+  return dir;
+}
+
+function runCli(configDir: string, args: string[], input?: string) {
+  return spawnSync(process.execPath, ['--import', 'tsx', cliEntry, ...args], {
+    input,
+    encoding: 'utf-8',
+    env: { ...process.env, PROMPT_SCRUB_CONFIG_DIR: configDir },
+  });
+}
+
+function writeRawConfig(configDir: string, contents: string) {
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, 'config.json'), contents, 'utf8');
+}
+
+test.before(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+test.after.always(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+test('CLI: init creates a default config file and its parent directories', (t) => {
+  const configDir = makeConfigDir();
+  const result = runCli(configDir, ['init']);
+
+  t.is(result.status, 0);
+  t.true(result.stdout.includes('Created config file at'));
+
+  const configPath = path.join(configDir, 'config.json');
+  t.true(fs.existsSync(configPath));
+  t.deepEqual(JSON.parse(fs.readFileSync(configPath, 'utf8')), {
+    rulePacks: [],
+    urlAllowlist: [],
+  });
+});
+
+test('CLI: init refuses to overwrite an existing config file', (t) => {
+  const configDir = makeConfigDir();
+  writeRawConfig(configDir, '{"rulePacks":["keep-me"]}');
+
+  const result = runCli(configDir, ['init']);
+
+  t.is(result.status, 1);
+  t.true(result.stderr.includes('already exists'));
+  t.true(result.stderr.includes('--force'));
+  t.true(fs.readFileSync(path.join(configDir, 'config.json'), 'utf8').includes('keep-me'));
+});
+
+test('CLI: init --force overwrites an existing config file', (t) => {
+  const configDir = makeConfigDir();
+  writeRawConfig(configDir, '{"rulePacks":["stale"],"bogus":1}');
+
+  const result = runCli(configDir, ['init', '--force']);
+
+  t.is(result.status, 0);
+  t.deepEqual(JSON.parse(fs.readFileSync(path.join(configDir, 'config.json'), 'utf8')), {
+    rulePacks: [],
+    urlAllowlist: [],
+  });
+});
+
+test('CLI: init --force creates the file when none exists', (t) => {
+  const configDir = makeConfigDir();
+  const result = runCli(configDir, ['init', '--force']);
+
+  t.is(result.status, 0);
+  t.true(fs.existsSync(path.join(configDir, 'config.json')));
+});
+
+test('CLI: config show prints defaults and a hint when no config file exists', (t) => {
+  const configDir = makeConfigDir();
+  const result = runCli(configDir, ['config', 'show']);
+
+  t.is(result.status, 0);
+  t.deepEqual(JSON.parse(result.stdout), { rulePacks: [], urlAllowlist: [] });
+  t.true(result.stderr.includes('No config file at'));
+  t.true(result.stderr.includes('prompt-scrub init'));
+});
+
+test('CLI: config show prints the active configuration and its path', (t) => {
+  const configDir = makeConfigDir();
+  writeRawConfig(
+    configDir,
+    JSON.stringify({ rulePacks: ['pack-a'], urlAllowlist: ['example.com'] }),
+  );
+
+  const result = runCli(configDir, ['config', 'show']);
+
+  t.is(result.status, 0);
+  t.deepEqual(JSON.parse(result.stdout), {
+    rulePacks: ['pack-a'],
+    urlAllowlist: ['example.com'],
+  });
+  t.true(result.stderr.includes(path.join(configDir, 'config.json')));
+});
+
+test('CLI: config show reports invalid JSON', (t) => {
+  const configDir = makeConfigDir();
+  writeRawConfig(configDir, '{ not json ');
+
+  const result = runCli(configDir, ['config', 'show']);
+
+  t.is(result.status, 1);
+  t.true(result.stderr.includes('Invalid JSON'));
+  t.deepEqual(JSON.parse(result.stdout), { rulePacks: [], urlAllowlist: [] });
+});
+
+test('CLI: config show reports an empty config file', (t) => {
+  const configDir = makeConfigDir();
+  writeRawConfig(configDir, '');
+
+  const result = runCli(configDir, ['config', 'show']);
+
+  t.is(result.status, 1);
+  t.true(result.stderr.includes('Invalid JSON'));
+});
+
+test('CLI: config show reports an unreadable config file', (t) => {
+  const configDir = makeConfigDir();
+  fs.mkdirSync(path.join(configDir, 'config.json'), { recursive: true });
+
+  const result = runCli(configDir, ['config', 'show']);
+
+  t.is(result.status, 1);
+  t.true(result.stderr.includes('Could not read file'));
+});
+
+test('CLI: config show reports a non-object root', (t) => {
+  const configDir = makeConfigDir();
+  writeRawConfig(configDir, '["pack-a"]');
+
+  const result = runCli(configDir, ['config', 'show']);
+
+  t.is(result.status, 1);
+  t.true(result.stderr.includes('Expected a JSON object, received an array'));
+});
+
+test('CLI: config show reports a null root', (t) => {
+  const configDir = makeConfigDir();
+  writeRawConfig(configDir, 'null');
+
+  const result = runCli(configDir, ['config', 'show']);
+
+  t.is(result.status, 1);
+  t.true(result.stderr.includes('Expected a JSON object, received null'));
+});
+
+test('CLI: config show reports unknown keys', (t) => {
+  const configDir = makeConfigDir();
+  writeRawConfig(configDir, JSON.stringify({ rulePaks: ['typo'] }));
+
+  const result = runCli(configDir, ['config', 'show']);
+
+  t.is(result.status, 1);
+  t.true(result.stderr.includes('Unknown key "rulePaks"'));
+  t.true(result.stderr.includes('rulePacks, urlAllowlist'));
+});
+
+test('CLI: config show reports keys with the wrong type', (t) => {
+  const configDir = makeConfigDir();
+  writeRawConfig(configDir, JSON.stringify({ rulePacks: 'pack-a', urlAllowlist: {} }));
+
+  const result = runCli(configDir, ['config', 'show']);
+
+  t.is(result.status, 1);
+  t.true(result.stderr.includes('"rulePacks" must be an array of strings, received string'));
+  t.true(result.stderr.includes('"urlAllowlist" must be an array of strings, received object'));
+});
+
+test('CLI: config show reports non-string array members and drops them', (t) => {
+  const configDir = makeConfigDir();
+  writeRawConfig(configDir, JSON.stringify({ rulePacks: ['pack-a', 42, null] }));
+
+  const result = runCli(configDir, ['config', 'show']);
+
+  t.is(result.status, 1);
+  t.true(result.stderr.includes('"rulePacks" must contain only strings'));
+  t.deepEqual(JSON.parse(result.stdout), { rulePacks: ['pack-a'], urlAllowlist: [] });
+});
+
+test('CLI: config show deduplicates repeated entries', (t) => {
+  const configDir = makeConfigDir();
+  writeRawConfig(configDir, JSON.stringify({ urlAllowlist: ['example.com', 'example.com'] }));
+
+  const result = runCli(configDir, ['config', 'show']);
+
+  t.is(result.status, 0);
+  t.deepEqual(JSON.parse(result.stdout), { rulePacks: [], urlAllowlist: ['example.com'] });
+});
+
+test('CLI: init output round-trips through config show', (t) => {
+  const configDir = makeConfigDir();
+  t.is(runCli(configDir, ['init']).status, 0);
+
+  const result = runCli(configDir, ['config', 'show']);
+  t.is(result.status, 0);
+  t.deepEqual(JSON.parse(result.stdout), { rulePacks: [], urlAllowlist: [] });
+});
+
+test('CLI: a configured urlAllowlist is applied when scrubbing', (t) => {
+  const configDir = makeConfigDir();
+  writeRawConfig(configDir, JSON.stringify({ urlAllowlist: ['example.com'] }));
+
+  const result = runCli(
+    configDir,
+    ['scrub'],
+    'See https://docs.example.com/a and https://other.io/b',
+  );
+
+  t.is(result.status, 0);
+  t.is(result.stdout, 'See https://docs.example.com/a and «Url_1»');
+});
+
+test('CLI: a malformed config file does not break scrubbing', (t) => {
+  const configDir = makeConfigDir();
+  writeRawConfig(configDir, '{ not json ');
+
+  const result = runCli(configDir, ['scrub'], 'Contact me at alice@example.com');
+
+  t.is(result.status, 0);
+  t.is(result.stdout, 'Contact me at «Email_1»');
+});
+
+test('CLI: help lists the init and config commands', (t) => {
+  const configDir = makeConfigDir();
+  const result = runCli(configDir, ['--help']);
+
+  t.is(result.status, 0);
+  t.true(result.stdout.includes('init'));
+  t.true(result.stdout.includes('config'));
+});


### PR DESCRIPTION
Closes #98

## Description

The config file schema was undiscoverable users had to hand-create `~/.config/prompt-scrub/config.json` and infer its shape from the docs.

- `prompt-scrub init` writes a default config file (and its parent directories), refusing to clobber an existing one unless `--force` is passed.
- `prompt-scrub config show` prints the active configuration as JSON on stdout and its source path on stderr, falling back to defaults when no file exists.
- Config files are now validated: unknown keys, wrong types, non-string array members, unreadable files and malformed JSON are reported with actionable messages and a non-zero exit, so `config show` doubles as a config check in scripts. Invalid entries are still dropped silently at scrub time, so a broken config never breaks a scrub.
- Corrects the rule-pack docs, which still pointed at the `package.json` `prompt-scrub` key removed in 1.0.1.

`loadConfig()` is now a thin wrapper over the new `readConfigFile()` same inputs, same outputs, no behaviour change for existing callers, and the library still writes nothing to stdout/stderr.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Checklist
- [x] If this was for an open issue, I was assigned to it
- [x] I have self-reviewed my code.
- [x] I have formatted, linted, and passed all tests (`pnpm run check`).
- [x] I have added/updated documentation if necessary.
- [x] I have added/updated tests if necessary.
- [x] I have NOT bumped the version in `package.json` (maintainers will handle this).