### PR TITLE
ci(changeset-check): read PR files via API instead of checking out fork code

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -4,6 +4,11 @@ name: Changeset Check
 # changeset, leave a single comment explaining how to add one. If a changeset is
 # later added, the comment is removed. This never fails the build - it only
 # keeps the release-notes pipeline fed.
+#
+# The PR's file list is read through the API rather than checked out. This job
+# runs as `pull_request_target`, so it carries the base repository's token and
+# secrets, and pulling fork code into that trusted context is what leads to
+# "pwn request" vulnerabilities. The check only ever needs filenames.
 
 on:
   pull_request_target:
@@ -19,35 +24,22 @@ jobs:
     runs-on: ubuntu-latest
     if: github.head_ref != 'changeset-release/main'
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      - name: Detect a changeset in this PR
-        id: detect
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          ADDED=$(git diff --name-only --diff-filter=A "$BASE_SHA" "$HEAD_SHA" \
-            | { grep -E '^\.changeset/.+\.md$' || true; } \
-            | { grep -v -E '^\.changeset/README\.md$' || true; })
-          if [ -n "$ADDED" ]; then
-            echo "has-changeset=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has-changeset=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Comment if missing (or clean up if present)
         uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- changeset-check -->';
-            const hasChangeset = ${{ steps.detect.outputs.has-changeset }};
             const {owner, repo} = context.repo;
             const issue_number = context.issue.number;
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: issue_number,
+            });
+            const hasChangeset = files.some(f =>
+              f.status === 'added' &&
+              /^\.changeset\/.+\.md$/.test(f.filename) &&
+              f.filename !== '.changeset/README.md'
+            );
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner, repo, issue_number,


### PR DESCRIPTION
### Problem

`changeset-check` currently fails on **every** pull request from a fork, including this one. It dies at the first step:

> Refusing to check out fork pull request code from a `pull_request_target` workflow.

`actions/checkout@v7` now blocks this by default (`allow-unsafe-pr-checkout: false`). The job runs as `pull_request_target`, so it carries the base repo's token and secrets pulling fork-authored code into that trusted context is the classic "pwn request" pattern, and checkout refuses it.

It shows up on #114 and #111, and passes only for dependabot, whose branches live in this repo rather than a fork.

Two knock-on effects: the check is documented as a non-blocking nudge that "never fails the build", but it now reports a red X on every outside contribution; and because it dies before its own logic runs, the changeset reminder never actually fires.

### Fix

The job never needed the fork's code. It checked out the full repository only to run `git diff --name-only --diff-filter=A` and look for an added `.changeset/*.md` a question about **filenames**. `pulls.listFiles` answers that from the API, so the checkout can go entirely.

That keeps `pull_request_target` (still required for `pull-requests: write` to post the comment) while removing fork content from the trusted context, rather than opting back into the risk with `allow-unsafe-pr-checkout: true`.

### Notes

- Detection rule is unchanged: added-only, `.changeset/*.md`, `README.md` excluded. Verified against the cases that matter — `config.json`/`changelog.cjs` still ignored as non-`.md`, `modified`/`removed` still ignored to match `--diff-filter=A`, and a `docs/.changeset/` lookalike still doesn't match.
- `listFiles` is paginated via `github.paginate`, matching the existing `listComments` call.
- It reports the diff against the **merge base**, which is a more accurate basis for "did this PR add a changeset" than the previous two-dot `git diff`.
- Computing the flag in JS also removes the `${{ steps.detect.outputs.has-changeset }}` expansion that was being interpolated into the script body.
- Net effect: two steps deleted, 8 fewer lines.

### Heads-up on verification

`pull_request_target` always loads the workflow from the base branch, so **this PR will still show the old failure** the fix can only take effect once it's on `main`. Worth a look at the workflow run on the next fork PR after merging to confirm it goes green.
