### PR TITLE
fix(ci): stop the changeset-check nudge from linking a real issue

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -74,7 +74,7 @@ jobs:
               "pnpm changeset",
               "```",
               "",
-              "Pick a bump (patch / minor / major) and write the changelog entry in our usual voice (\"Added **X**... Closes #123.\"), then commit the generated `.changeset/*.md` file.",
+              "Pick a bump (patch / minor / major) and write the changelog entry in our usual voice (`Added **X**... Closes #<issue>.`), then commit the generated `.changeset/*.md` file.",
               "",
               "If this PR is docs-only or a chore that needs no release note, you can ignore this - or run `pnpm changeset --empty` to record that intentionally.",
             ].join("\n");


### PR DESCRIPTION
## Description

The `changeset-check` workflow posts a friendly "No changeset found" nudge on PRs that add no changeset. Inside that comment is an example changelog line:

```
Pick a bump (patch / minor / major) and write the changelog entry in our usual
voice ("Added **X**... Closes #123."), then commit the generated `.changeset/*.md` file.
```

The `#123` there is a made-up placeholder. But GitHub autolinks any bare `#<number>` in a comment body it has no way to know the number is illustrative. So every time the bot posts that comment, GitHub files a cross-reference on the **real** issue 123, which is an unrelated bug report ("Windows paths leak in cleartext when an email or secret appears later on the same line").

### What this looked like in practice

Sequence from 2026-08-27, on the `feature/add-json-option` PR (adding `--json` to the CLI):

| Time (UTC) | What happened |
|---|---|
| 08:47 | Issue 123 opened, Windows path leak |
| 09:57:44 | The `--json` PR opened; first commit had no changeset |
| 09:57:47 | `Changeset Check` run `33060927012` starts |
| 09:57:57 | Bot posts the nudge → GitHub records a cross-reference on issue 123 |
| 10:06:49 | Author pushes a changeset; run `33061608991` deletes the bot's comment |

Net result: issue 123 shows "mentioned by" that PR, even though the PR's body, both commit messages, and its diff never reference issue 123 anywhere. The two are completely unrelated pieces of work.

### Why it doesn't clean up after itself

The `hasChangeset` branch deletes the bot's own comment once a changeset appears  which is good behaviour, and it works. But GitHub does **not** retract a cross-reference when the comment that created it is deleted.

So the end state is the confusing one: the PR shows **zero comments** (`"comments": 0`, no reviews, no review comments), while the issue keeps a permanent "mentioned by" entry pointing at a PR that visibly never mentioned it. There's no trace left of what caused the link, which makes it fairly hard to diagnose from the UI alone.

### Scope

This isn't a one-off. The detect step keys purely on whether the diff adds a `.changeset/*.md` file, so **every** PR that opens without one re-posts the nudge and adds another stray mention to issue 123. It accumulates indefinitely, and it will always land on that one issue.

## The fix

One line. Two changes to the placeholder, belt and braces:

1. Wrap the example in a code span GitHub does not autolink inside code spans.
2. Replace the number with `#<issue>`, so there is no number left to link even if the backticks get dropped in a future edit.

```diff
-              "Pick a bump (patch / minor / major) and write the changelog entry in our usual voice (\"Added **X**... Closes #123.\"), then commit the generated `.changeset/*.md` file.",
+              "Pick a bump (patch / minor / major) and write the changelog entry in our usual voice (`Added **X**... Closes #<issue>.`), then commit the generated `.changeset/*.md` file.",
```

The rendered comment is unchanged apart from the example now showing in monospace which arguably reads a little better anyway, since it is showing literal Markdown the contributor is meant to type.

Only the nudge's wording changes. Detection, commenting, updating, and cleanup all behave exactly as before.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing Notes

- Workflow-only change no source files, no test files touched.
- Verified the embedded `actions/github-script` body still parses as valid JavaScript after the edit (backticks inside a double-quoted JS string are fine, and the escaped inner quotes are no longer needed).
- Confirmed the edit sits inside the YAML block scalar with indentation unchanged, so the workflow structure is untouched.
- No behavioural test is practical here the bug only manifests in GitHub's own comment rendering but the change is confined to a string literal.

One note: this PR adds no changeset itself, so the nudge will fire on it one last time and produce one final stray mention on issue 123. Once this merges, that stops.

## Checklist
- [x] If this was for an open issue, I was assigned to it no issue was filed; raised directly with @akramcodez, who asked me to open the PR
- [x] I have self-reviewed my code.
- [x] I have formatted, linted, and passed all tests (`pnpm run check`) n/a, no source changes; workflow YAML only
- [x] I have added/updated documentation if necessary.
- [x] I have added/updated tests if necessary.
- [x] I have NOT bumped the version in `package.json` (maintainers will handle this).
- [x] I have added a changeset for user-facing changes (`pnpm changeset`) or noted in the PR description that one isn't needed **chore / CI only, no changeset needed**
