### PR TITLE
chore: own code through the core team, not individuals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,33 +1,3 @@
-# Root level - main maintainers
-* @will-lamerton @akramcodez
-
-# Core scrubbing pipeline
-src/core/* @will-lamerton @akramcodez
-
-# Detectors
-src/detectors/* @will-lamerton @akramcodez
-
-# Session management and storage
-src/session/* @will-lamerton @akramcodez
-
-# CLI
-src/cli/**/* @will-lamerton @akramcodez
-
-# Shared types
-src/types/* @will-lamerton @akramcodez
-
-# Test files
-tests/**/* @will-lamerton @akramcodez
-
-# Build and configuration files
-package.json @will-lamerton @akramcodez
-tsconfig.json @will-lamerton @akramcodez
-biome.json @will-lamerton @akramcodez
-
-# Documentation
-docs/**/* @will-lamerton @akramcodez
-README.md @will-lamerton @akramcodez
-CONTRIBUTING.md @will-lamerton @akramcodez
-
-# GitHub workflows and configurations
-.github/**/* @will-lamerton @akramcodez
+# Ownership is held by the team, not by individuals. This replaces thirteen
+# per-path lines that all named the same two people.
+* @Nano-Collective/core-team


### PR DESCRIPTION
Implements step 6 of the ops scaling work.

## Why

`Review gates` sets `require_code_owner_review: true`. A repository with **no** `CODEOWNERS` satisfies that requirement vacuously — there is no owner, so there is nothing to review. `nanotune` and `nanoterm` were in that state.

Where a `CODEOWNERS` did exist, it named a single person on `sentinel`, `get-md` and `json-up`. Sole ownership is the bottleneck this whole piece of work exists to remove.

## Why the team rather than names

`@Nano-Collective/core-team` holds `maintain` on all seven package repositories, which satisfies GitHub's write-access requirement for a team code owner.

Using the team means adding a maintainer is one team membership change, not seven pull requests against seven `CODEOWNERS` files that will drift apart. It is the same reasoning that moved repository access onto teams in the first place.
