### PR TITLE
chore: use the shared release workflows

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,9 +1,7 @@
 name: Changeset Check
 
-# Friendly, NON-BLOCKING nudge: if a pull request changes source but adds no
-# changeset, leave a single comment explaining how to add one. If a changeset is
-# later added, the comment is removed. This never fails the build - it only
-# keeps the release-notes pipeline fed.
+# Thin caller for the shared org workflow. Non-blocking: comments when a pull
+# request adds no changeset, removes the comment when one appears.
 
 on:
   pull_request_target:
@@ -11,76 +9,8 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
   pull-requests: write
 
 jobs:
   changeset-check:
-    runs-on: ubuntu-latest
-    if: github.head_ref != 'changeset-release/main'
-    steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          allow-unsafe-pr-checkout: true
-
-      - name: Detect a changeset in this PR
-        id: detect
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          ADDED=$(git diff --name-only --diff-filter=A "$BASE_SHA" "$HEAD_SHA" \
-            | { grep -E '^\.changeset/.+\.md$' || true; } \
-            | { grep -v -E '^\.changeset/README\.md$' || true; })
-          if [ -n "$ADDED" ]; then
-            echo "has-changeset=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has-changeset=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Comment if missing (or clean up if present)
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const marker = '<!-- changeset-check -->';
-            const hasChangeset = ${{ steps.detect.outputs.has-changeset }};
-            const {owner, repo} = context.repo;
-            const issue_number = context.issue.number;
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-
-            if (hasChangeset) {
-              if (existing) {
-                await github.rest.issues.deleteComment({owner, repo, comment_id: existing.id});
-              }
-              return;
-            }
-
-            const body = [
-              marker,
-              "### No changeset found",
-              "",
-              "This PR does not add a changeset, so it will not appear in the changelog or trigger a release.",
-              "",
-              "If the change is user-facing, add one:",
-              "",
-              "```bash",
-              "pnpm changeset",
-              "```",
-              "",
-              "Pick a bump (patch / minor / major) and write the changelog entry in our usual voice (`Added **X**... Closes #<issue>.`), then commit the generated `.changeset/*.md` file.",
-              "",
-              "If this PR is docs-only or a chore that needs no release note, you can ignore this - or run `pnpm changeset --empty` to record that intentionally.",
-            ].join("\n");
-
-            if (existing) {
-              await github.rest.issues.updateComment({owner, repo, comment_id: existing.id, body});
-            } else {
-              await github.rest.issues.createComment({owner, repo, issue_number, body});
-            }
+    uses: Nano-Collective/.github/.github/workflows/changeset-check.yml@main

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,3 +16,5 @@ permissions:
 jobs:
   pr-checks:
     uses: Nano-Collective/.github/.github/workflows/pr-checks.yml@main
+    with:
+      validate-changesets: true

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,52 +1,19 @@
 name: Prepare Release (Version PR)
 
-# Keeps a single open "Version Packages" pull request up to date. As changesets
-# land on main, this PR accumulates them, bumps package.json, and rolls the
-# entries into CHANGELOG.md (in our house style, via changeset:version).
+# Thin caller for the shared org workflow. Everything lives in
+# Nano-Collective/.github — change it there and every repo picks it up.
 #
-# This workflow NEVER publishes. Merging the Version PR pushes a version bump to
-# main, which the existing release.yml detects and publishes. That split keeps
-# release.yml the single source of truth for publishing.
+# This never publishes. Merging the Version Packages PR it maintains pushes a
+# version bump to main, which release.yml detects and publishes.
 
 on:
   push:
     branches: [main]
-
-# Avoid racing the Version PR against itself on rapid merges.
-concurrency:
-  group: release-prepare
-  cancel-in-progress: false
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
-  version:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Create or update the Version Packages PR
-        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
-        with:
-          version: pnpm run changeset:version
-          title: 'chore: version packages'
-          commit: 'chore: version packages'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release-prepare:
+    uses: Nano-Collective/.github/.github/workflows/release-prepare.yml@main


### PR DESCRIPTION
Completes step 10 for this repo: local copies of `release-prepare.yml` and `changeset-check.yml` are replaced with thin callers into [`Nano-Collective/.github`](https://github.com/Nano-Collective/.github), and `validate-changesets` is turned on.

## This fixes two things, it does not just deduplicate

### 1. An unsafe `pull_request_target` checkout

The local `changeset-check.yml` did this:

```yaml
on:
  pull_request_target: ...
permissions:
  pull-requests: write
steps:
  - uses: actions/checkout@...
    with:
      ref: ${{ github.event.pull_request.head.sha }}
      allow-unsafe-pr-checkout: true
```

Contributor-controlled code on disk, in a job holding a write-scoped token. **Not exploitable** — nothing executed the checked-out tree — but one added build step away from being so. The plan flagged this repo specifically.

The checkout was never necessary: `pulls.listFiles` returns the filenames as data. The shared version uses that, so there is nothing on disk to execute.

### 2. No changeset validator

This repo had `changeset-check` but no validator, so **nothing checked that the package name inside a changeset resolves**. That is precisely the gap that broke `release-prepare` on nanocoder's `main` for every push until someone noticed (#1065). `validate-changesets: true` closes it without adding a script here.

## Unchanged

`changeset:version` still runs `changeset version && node scripts/normalize-changelog.js`. The shared workflow takes the script name as an input specifically so repos that post-process `CHANGELOG.md` keep doing so.

Publishing is untouched — `release-prepare` never publishes; `release.yml` still owns that.
