### PR TITLE
ci: adopt nc-review

### DIFF
--- a/.github/nc-review/rubric.md
+++ b/.github/nc-review/rubric.md
@@ -1,0 +1,121 @@
+# nc-review rubric — prompt-scrub
+
+This is the **project** half of the rubric: what prompt-scrub cares about. The
+reviewing method — how to read a diff against a base checkout, how to rate
+severity, what to emit — is the shared base rubric you were also given. Read
+both; where they disagree, this file wins.
+
+## What this project is, and why that changes review
+
+prompt-scrub strips identifying content out of a prompt **before it leaves the
+user's machine**, replaces each value with a stable placeholder, and rehydrates
+the model's reply afterwards.
+
+So the failure that matters here is not a crash. It is **a value that should
+have been replaced and was not**, because that value has already reached a
+third-party LLM by the time anyone notices. A missed detection is silent, and
+it is unrecoverable.
+
+Weigh findings accordingly:
+
+- **A leak is `blocking`**, even if it needs an unusual input to trigger.
+- **Over-scrubbing is `important`**, not `blocking` — it corrupts the user's
+  prose and is annoying, but it does not disclose anything.
+- A crash is usually `important`. It is loud, and loud failures in this product
+  are safe failures.
+
+The README is explicit that this is *partial defence, not anonymity*. Do not
+file findings demanding guarantees the project does not claim. Do file them when
+a change quietly weakens a defence it does claim.
+
+## Where the bugs actually are
+
+Every one of these has shipped or been fixed here. Check them before anything
+else.
+
+### Span arithmetic in detectors
+
+A detector returns a span, and the scrubber splices on it. If the start index is
+derived from the wrong thing — the match group rather than `match[0]`, or a
+length that does not account for a leading separator — the splice lands off by a
+few characters. That either leaves part of the original in place (a leak) or
+eats a neighbouring character (corruption). See the phone detector's history.
+
+When a diff touches span or index computation, work the arithmetic yourself
+against a concrete example before accepting it.
+
+### Overlapping matches between detectors
+
+Two detectors can match overlapping regions of the same line — a path
+immediately followed by an email, a secret inside a URL. If the resolution order
+or the offset bookkeeping is wrong, one replacement shifts the other's span and
+something survives unredacted. This has produced a real leak on Windows paths.
+
+Ask: what happens when this detector's match is adjacent to, or contained by,
+another's on the same line?
+
+### Over-matching prose
+
+The name, postal-address and code-tell detectors work on natural language and
+will happily eat ordinary sentences. A change that widens one of these needs to
+show it does not swallow prose.
+
+### Placeholder identity and collisions
+
+Placeholders must be **stable within a session** — the same value always maps to
+the same placeholder, and two different values never share one. Rehydration
+depends entirely on that. A change touching the collision resolver, the session
+map, or anything that decides when a new session begins should be read against
+both properties. Watch mode in particular has had a bug where a fresh session
+per message let placeholders collide.
+
+### Rehydration is exact or it is wrong
+
+Rehydrate must restore the original text, not an approximation. A partial or
+fuzzy restore hands the user output that looks right and is not.
+
+## Local-first is a hard constraint
+
+Nothing in the scrub path may make a network call, and no dependency added to
+that path may either. A new runtime dependency in `src/` deserves a look at what
+it does on import. This is a tool people run *because* they do not trust the
+network; a phone-home in it would be the worst possible defect.
+
+Session files hold the mapping between placeholders and the **original**
+sensitive values. Treat anything that changes where they are written, what is in
+them, or their permissions as security-relevant.
+
+## Public contracts
+
+Breaking these is `blocking` without a matching changeset and a deliberate
+version bump:
+
+- **The placeholder format.** Sessions written by an older version are
+  rehydrated by a newer one; change the format and you break that.
+- **The session file shape** — `SessionMap` and what `src/session/storage.ts`
+  persists.
+- **`Detector`, `Finding`, `ScrubResult`, `RehydrateResult`** and the rest of
+  `src/types/` — these are exported and third-party rule packs depend on them.
+- **CLI flags and the config schema** across `scrub`, `rehydrate`, `inspect`,
+  `sessions`, `watch`, `rules`, `config`.
+
+## Tests
+
+Tests live in **`tests/**/*.test.ts`** — a separate tree, not colocated, and not
+`.spec.ts`. Ava is configured to look only there, so a test file put next to the
+source will silently never run. That is worth flagging when you see it.
+
+A new or modified detector needs cases for:
+
+- the value it is meant to catch, in isolation
+- the same value adjacent to another detector's match on one line
+- something similar that it must **not** match
+
+A detector change with only a positive case is under-tested; say so, because the
+negative case is where over-matching hides.
+
+## Scope
+
+Detectors are the easiest place to contribute and the easiest place to do harm,
+so expect many small detector PRs. Judge them on whether the pattern is right
+and the tests prove it, not on size.

--- a/.github/workflows/nc-review.yml
+++ b/.github/workflows/nc-review.yml
@@ -1,0 +1,67 @@
+name: nc-review
+
+# Thin caller for the shared org workflow. The machinery lives in
+# Nano-Collective/.github — change it there and every repo picks it up on its
+# next run. What stays here is the trigger wiring and the rubric.
+#
+# The rubric is deliberately NOT shared. It is where a project says what it
+# cares about — its conventions, its test layout, the mistakes it keeps seeing.
+# Sharing it would produce reviews that read the same everywhere and land
+# nowhere. Same split as pr-checks: shared machinery, local judgement.
+#
+# Before adopting this in a repo you need two things:
+#
+#   1. `.github/nc-review/rubric.md` in this repository.
+#   2. MINIMAX_API_KEY readable here — set it once as an ORGANISATION secret
+#      with visibility "all". Organisation Actions secrets are available to
+#      public repositories on the Free plan (verified 2026-09-07), so there is
+#      no need to copy the key into each repo.
+#
+# Retire `copilot_code_review` from that repo's Review gates ruleset only once
+# this is live and producing verdicts — removing it earlier leaves the repo with
+# no automated review at all, which inverts decision Q7.
+
+on:
+  pull_request_target:
+    # On open only (decision Q8). Re-review is manual, via the comment trigger
+    # below — re-running on every push would burn tokens on work in progress.
+    types: [opened]
+    branches: [main]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to review
+        required: true
+        type: string
+
+concurrency:
+  # One review per PR. A /re-review while one is running queues behind it.
+  group: nc-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  nc-review:
+    uses: Nano-Collective/.github/.github/workflows/nc-review.yml@main
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    with:
+      # Only ever non-empty on workflow_dispatch, and that is deliberate.
+      # The shared workflow resolves the PR itself with
+      #   github.event.pull_request.number || github.event.issue.number || inputs.pr-number
+      # so pull_request_target and issue_comment are covered by the event, and
+      # this input is purely the manual-dispatch fallback. Do not duplicate that
+      # expression here — it would be the same logic in nine callers, drifting.
+      pr-number: ${{ inputs.pr_number }}
+      # No architecture document in this repo; the rubric carries the shape.
+      architecture-doc: ''
+    secrets:
+      MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}


### PR DESCRIPTION
Second repository onto the shared review workflow, after nanocoder. **Two files**: the caller, and this project's own rubric.

The reviewing method is not copied — it is fetched from [`Nano-Collective/.github`](https://github.com/Nano-Collective/.github/blob/main/nc-review/rubric-base.md) at run time. What is here is only what a reviewer new to prompt-scrub would get wrong.

## Why this rubric is not boilerplate

**The failure that matters here is a missed detection, not a crash.** A value that should have been replaced and was not has already reached a third-party LLM by the time anyone notices, and it cannot be recalled. So the weighting is inverted from the usual:

| | |
|---|---|
| a leak | **blocking**, even on an unusual input |
| over-scrubbing | **important** — corrupts prose, discloses nothing |
| a crash | usually **important** — loud failures are safe failures here |

**The recurring bug classes are named, and every one has shipped here:**

- **Span arithmetic in detectors** — a start index derived from the wrong group or a length missing a separator splices a few characters off, leaving part of the original in place. cf. #104.
- **Overlapping matches between detectors** — a path immediately followed by an email; wrong offset bookkeeping and one survives unredacted. cf. #127.
- **Prose-eating** in the name, postal-address and code-tell detectors. cf. #103.
- **Placeholder collisions** when session identity changes. cf. #128.
- **Inexact rehydration** — output that looks right and is not.

**Local-first is stated as a hard constraint**, including for newly added dependencies in the scrub path. This is a tool people run *because* they do not trust the network.

**The public contracts are the placeholder format and the session file shape**, because a session written by an older version must rehydrate under a newer one.

## Two details that would trip up a reviewer carrying nanocoder's conventions

- **Tests are `tests/**/*.test.ts`**, a separate tree — not colocated `.spec.ts`. Ava is configured to look only there, so a test placed beside the source **silently never runs**. The rubric flags that explicitly.
- **`architecture-doc` is set empty** — this repo has no `CLAUDE.md`, and the shared workflow omits a document it cannot find rather than sending the agent hunting for it.

## Rollout note

**Copilot review stays on this repo** until nc-review is actually producing verdicts here — removing it first would leave the repo with no automated review at all, which inverts Q7.

The shared path is already verified on nanocoder for `workflow_dispatch` and `issue_comment`. As with any caller, `pull_request_target` resolves the workflow from the **base** branch, so this PR will not be reviewed by it — the first PR opened after merge will.