### PR TITLE
ci: call the shared release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,11 @@
 name: Release to NPM and GitHub
 
+# Thin caller for the shared org workflow. Everything lives in
+# Nano-Collective/.github — change it there and every repo picks it up.
+#
+# Publishes only when package.json's version is ahead of npm, so merging the
+# Version Packages PR is what triggers a release. Nothing else does.
+
 on:
   push:
     branches: [main]
@@ -7,185 +13,16 @@ on:
 permissions:
   contents: write
   packages: write
+  # Required for npm publish --provenance (OIDC build attestation).
+  id-token: write
 
 jobs:
-  check-version:
-    runs-on: ubuntu-latest
-    outputs:
-      should-publish: ${{ steps.version-check.outputs.should-publish }}
-      package-version: ${{ steps.version-check.outputs.package-version }}
-      npm-version: ${{ steps.version-check.outputs.npm-version }}
-      is-prerelease: ${{ steps.version-check.outputs.is-prerelease }}
-      npm-tag: ${{ steps.version-check.outputs.npm-tag }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: "22"
-
-      - name: Check version difference
-        id: version-check
-        run: |
-          # Get current package.json version
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          echo "package-version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
-
-          # Detect prerelease versions (beta, alpha, rc, etc.)
-          if [[ "$PACKAGE_VERSION" == *"-beta"* ]]; then
-            echo "is-prerelease=true" >> $GITHUB_OUTPUT
-            echo "npm-tag=beta" >> $GITHUB_OUTPUT
-            echo "Beta version detected: $PACKAGE_VERSION"
-          elif [[ "$PACKAGE_VERSION" == *"-alpha"* ]]; then
-            echo "is-prerelease=true" >> $GITHUB_OUTPUT
-            echo "npm-tag=alpha" >> $GITHUB_OUTPUT
-            echo "Alpha version detected: $PACKAGE_VERSION"
-          elif [[ "$PACKAGE_VERSION" == *"-rc"* ]]; then
-            echo "is-prerelease=true" >> $GITHUB_OUTPUT
-            echo "npm-tag=rc" >> $GITHUB_OUTPUT
-            echo "Release candidate detected: $PACKAGE_VERSION"
-          else
-            echo "is-prerelease=false" >> $GITHUB_OUTPUT
-            echo "npm-tag=latest" >> $GITHUB_OUTPUT
-          fi
-
-          # Get the version currently published on npm (empty string if not published yet)
-          NPM_VERSION=$(npm view @nanocollective/prompt-scrub version 2>/dev/null || echo "")
-          echo "npm-version=$NPM_VERSION" >> $GITHUB_OUTPUT
-
-          if [ "$PACKAGE_VERSION" != "$NPM_VERSION" ]; then
-            echo "should-publish=true" >> $GITHUB_OUTPUT
-            echo "Version bump detected: $NPM_VERSION -> $PACKAGE_VERSION"
-          else
-            echo "should-publish=false" >> $GITHUB_OUTPUT
-            echo "No version bump, skipping publish."
-          fi
-
-  publish:
-    needs: check-version
-    if: needs.check-version.outputs.should-publish == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: "22"
-          cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm run build
-
-      - name: Run full test suite
-        run: pnpm test:all
-
-      - name: Verify build output
-        run: |
-          if [ ! -f "dist/cli/index.js" ]; then
-            echo "Build output missing: dist/cli/index.js not found"
-            exit 1
-          fi
-          echo "Build output verified: dist/cli/index.js exists"
-
-      - name: Publish to npm
-        run: npm publish --tag ${{ needs.check-version.outputs.npm-tag }} --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Extract changelog
-        id: changelog
-        run: |
-          if CHANGELOG=$(node scripts/extract-changelog.js 2>/dev/null); then
-            echo "Changelog extracted for v${{ needs.check-version.outputs.package-version }}"
-          else
-            CHANGELOG="See the commit history for changes in this release."
-            echo "No changelog entry found for v${{ needs.check-version.outputs.package-version }}; using fallback."
-          fi
-          {
-            echo "CHANGELOG<<CHANGELOG_EOF"
-            echo "$CHANGELOG"
-            echo "CHANGELOG_EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Create GitHub Release
-        uses: actions/github-script@v9
-        env:
-          CHANGELOG: ${{ steps.changelog.outputs.CHANGELOG }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const version = '${{ needs.check-version.outputs.package-version }}';
-            const isPrerelease = '${{ needs.check-version.outputs.is-prerelease }}' === 'true';
-            const tag = `v${version}`;
-
-            const changelog = (process.env.CHANGELOG || '').trim();
-
-            const body = [
-              `## prompt-scrub v${version}`,
-              '',
-              ...(changelog ? ['### What\'s changed', '', changelog, ''] : []),
-              '### Installation',
-              '```bash',
-              'npm install -g @nanocollective/prompt-scrub',
-              '```',
-              '',
-              '### CLI usage',
-              '```bash',
-              '# Inspect a prompt before sending (recommended first step)',
-              'echo "My email is alice@example.com" | prompt-scrub inspect',
-              '',
-              '# Scrub a prompt',
-              'echo "My email is alice@example.com" | prompt-scrub scrub',
-              '',
-              '# Rehydrate a response',
-              'echo "Contact Email_1 for details." | prompt-scrub rehydrate --session-id <id>',
-              '```',
-              '',
-              '### Library usage',
-              '```typescript',
-              'import { scrub, rehydrate } from "@nanocollective/prompt-scrub";',
-              '',
-              'const { scrubbedContent, sessionId } = scrub({ content: prompt });',
-              '// send scrubbedContent to LLM...',
-              'const { content } = rehydrate({ content: response, sessionId });',
-              '```',
-              '',
-              `[Full changelog](https://github.com/Nano-Collective/prompt-scrubber/commits/v${version})`,
-            ].join('\n');
-
-            await github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: tag,
-              name: `v${version}`,
-              body,
-              prerelease: isPrerelease,
-              generate_release_notes: false,
-            });
-
-            console.log(`GitHub Release created: ${tag}`);
-
-  notify:
-    needs: [check-version, publish]
-    if: always() && needs.check-version.outputs.should-publish == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify result
-        run: |
-          if [ "${{ needs.publish.result }}" == "success" ]; then
-            echo "@nanocollective/prompt-scrub@${{ needs.check-version.outputs.package-version }} published successfully."
-          else
-            echo "Publish failed for @nanocollective/prompt-scrub@${{ needs.check-version.outputs.package-version }}."
-            exit 1
-          fi
+  release:
+    uses: Nano-Collective/.github/.github/workflows/release.yml@main
+    with:
+      # The CLI lives at dist/cli/index.js here, not dist/cli.js — the bin
+      # entry points at it, so a build that misses it ships a broken package.
+      verify-files: 'dist/index.js dist/cli/index.js'
+      install-command: 'npm install -g {pkg}'
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/knip.json
+++ b/knip.json
@@ -2,5 +2,6 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "ignoreDependencies": [],
   "ignoreBinaries": ["semgrep", "pbcopy", "pbpaste", "xclip", "osascript", "notify-send"],
-  "ignoreWorkspaces": ["examples/*"]
+  "ignoreWorkspaces": ["examples/*"],
+  "entry": ["scripts/extract-changelog.js"]
 }


### PR DESCRIPTION
The last duplicated workflow. The machinery moves to [`Nano-Collective/.github`](https://github.com/Nano-Collective/.github/blob/main/.github/workflows/release.yml).

## Why this repo first

Six repos ran the same four jobs — `check-version`, `publish`, release, `notify` — from files that had drifted to between **76 and 256 lines**. The drift here is not cosmetic:

- **Every action was pinned by mutable tag**, which Semgrep flags as `github-actions-mutable-action-tag`. Centralising `update-badges` already moved this repo's advisory scan down; **the remaining mutable-tag finding is this file.**
- The shared workflow pins everything by SHA.

## What is parameterised, and what is not

Only what actually varied: build and test scripts, the files the build must produce, the changelog script, the release name, and the install line.

**The npm package name is derived from `package.json`** rather than restated — that is how a copy ends up publishing under the wrong name after a rename.

## Two behaviours kept deliberate rather than incidental

- **`check-version` reads the full published version list**, not `npm view … version`. That call resolves the `latest` dist-tag, which pre-1.0 lags behind the newest prerelease — so an already-published version would read as new and the publish would fail on every push. The list makes it an exact membership test.
- **The Discord announcement cannot fail a release that already shipped.** Skipped when the webhook is unset, and it swallows its own errors.

## On risk

The version guard is what makes this safe to change: nothing publishes unless `package.json` is genuinely ahead of the registry. So the failure mode of a mistake in here is **a release that does not happen** — loud and fixable — rather than one that ships the wrong thing.

I cannot test a real publish without cutting a release, so I verified what could be verified in isolation: prerelease tag detection across stable/alpha/beta/rc, the install-template substitution, and the already-published membership test. All correct.

`verify-files` is set to what this package actually ships, checked against its `main` and `bin` entries — an npm publish of an empty package succeeds silently, so that check is the one that matters.
